### PR TITLE
US-1.3: Feature - Add CampusToggle button

### DIFF
--- a/mobile/src/components/CampusToggle.tsx
+++ b/mobile/src/components/CampusToggle.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+import type { Campus } from '../types/Campus';
+import styles from '../styles/CampusToggle.styles';
+
+type Props = {
+  selectedCampus: Campus;
+  onToggle: () => void;
+}
+
+const CampusToggle = ({ selectedCampus, onToggle }: Props) => {
+  let nextCampus;
+  if (selectedCampus === 'SGW') {
+    nextCampus = 'LOYOLA';
+  } else {
+    nextCampus = 'SGW';
+  }
+
+  let nextLabel;
+  if (nextCampus === 'SGW') {
+    nextLabel = 'SGW';
+  } else {
+    nextLabel = 'LOY';
+  }
+
+  return (
+    <View style={styles.wrapper}>
+      <Pressable
+        accessibilityRole='button'
+        accessibilityLabel={`${nextCampus}`}
+        onPress={onToggle}
+        style={styles.button}
+      >
+        <Text style={styles.label}>{nextLabel}</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+
+export default CampusToggle;
+
+

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -8,6 +8,7 @@ import { getCampusRegion } from '../constants/campuses';
 import styles, { POLYGON_THEME } from '../styles/MapScreen.styles';
 import { getCampusBuildingShapes, getBuildingShapeById } from '../utils/buildingsRepository';
 import type { PolygonRenderItem } from '../types/Map';
+import CampusToggle from '../components/CampusToggle';
 
 export default function MapScreen() {
   const [selectedCampus, setSelectedCampus] = useState<Campus>('SGW');
@@ -81,6 +82,12 @@ export default function MapScreen() {
     return getBuildingShapeById(selectedBuildingId) ?? null;
   }, [selectedBuildingId]);
 
+  // For the toggle button:
+  const handleToggleCampus = () => {
+    setSelectedCampus((prev) => (prev === 'SGW' ? 'LOYOLA' : 'SGW'));
+    setSelectedBuildingId(null);
+  };
+
   return (
     <View style={styles.container}>
       <MapView
@@ -115,6 +122,9 @@ export default function MapScreen() {
 
         {userCoords && <Marker coordinate={userCoords} title="You are here" />}
       </MapView>
+
+      <CampusToggle selectedCampus={selectedCampus} onToggle={handleToggleCampus} />
+
 
       <View style={styles.overlay}>
         <Text style={styles.overlayTitle}>GitToCampus</Text>

--- a/mobile/src/styles/CampusToggle.styles.ts
+++ b/mobile/src/styles/CampusToggle.styles.ts
@@ -1,0 +1,37 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'absolute',
+    right: 16,
+    bottom: 80,
+  },
+  button: {
+    width: 52,
+    height: 52,
+    borderRadius: 26,
+    backgroundColor: '#4a4a4a',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: '#1f2937',
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 4,
+  },
+  buttonPressed: {
+    transform: [{ scale: 0.96 }],
+    opacity: 0.85,
+  },
+  label: {
+    fontFamily: 'Gabarito-Bold',
+    color: '#d8d8d8',
+    fontWeight: '700',
+    fontSize: 14,
+    letterSpacing: 0.5,
+  },
+});
+
+export default styles;


### PR DESCRIPTION
## Summary
Implements `TASK-1.3.1` and `TASK-1.3.2` under `US-1.3` by adding a campus toggle button that switches the map view and campus building shapes between SGW and Loyola.

## Changes
- Added `CampusToggle` component with button UI for switching campuses
- Wired the toggle to `selectedCampus` state and map camera animation

## How to Test
1. Start the app and open the map screen.
2. Tap the toggle button in the bottom‑right corner.
3. Confirm the map centers on the other campus and polygons update accordingly.

## Notes
- Persistence (remembering last campus on reopen) is not implemented.
- Styling can be refined later if we want pixel‑perfect matching.

## Checklist
- [x] Builds/runs locally (or via Expo Go / emulator)
- [x] Meets acceptance criteria for the linked task/user story
- [x] Lint/format checks pass (if configured)
- [x] Tests added/updated (if applicable)
- [x] Screenshots included (for UI changes)
- [x] Ready to squash & merge

## Screenshot
<img width="375" height="777" alt="image" src="https://github.com/user-attachments/assets/4fdd0aae-47a5-4063-aa53-15e2a8b88190" />

Closes #7 