### PR TITLE
REFAC/US-2.4.2 resolve code quality warnings

### DIFF
--- a/mobile/maestro/at_2_3.yaml
+++ b/mobile/maestro/at_2_3.yaml
@@ -53,20 +53,19 @@ appId: host.exp.exponent
     text: Henry F. Hall Building
 
 # Tap "Set as starting point" button
-- tapOn: " Set as starting point "
+- tapOn: ' Set as starting point '
 
 # Verify directions modal appears
-- assertVisible: " Directions "
+- assertVisible: ' Directions '
 
 # Verify the selected building is now the starting point
 - assertVisible:
     text: Henry F. Hall Building
 
 # Verify we can select a destination
-- tapOn:
-    point: '50%,80%'
+- tapOn: Set destination
+- tapOn: J.W. McConnell Building
 
 # Verify destination is set
-- extendedWaitUntil:
-    visible: 'Set destination'
-    timeout: 1000
+- assertVisible: ' Directions '
+- assertVisible: J.W. McConnell Building

--- a/mobile/src/utils/polyline.ts
+++ b/mobile/src/utils/polyline.ts
@@ -1,5 +1,29 @@
 import type { LatLng } from 'react-native-maps';
 
+const decodeNextValue = (
+  encoded: string,
+  index: number,
+): { value: number; index: number } | null => {
+  let result = 0;
+  let shift = 0;
+  let byte: number;
+
+  do {
+    if (index >= encoded.length) return null;
+
+    const codePoint = encoded.codePointAt(index++);
+
+    if (codePoint === undefined) return null;
+
+    byte = codePoint - 63;
+    result |= (byte & 0x1f) << shift;
+    shift += 5;
+  } while (byte >= 0x20);
+
+  const value = result & 1 ? ~(result >> 1) : result >> 1;
+  return { value, index };
+};
+
 /**
  * Decodes a Google encoded polyline string into LatLng coordinates.
  * Returns [] for empty or malformed input.
@@ -13,27 +37,15 @@ export const decodePolyline = (encoded: string): LatLng[] => {
   const points: LatLng[] = [];
 
   while (index < encoded.length) {
-    let result = 0;
-    let shift = 0;
-    let byte: number;
+    const latResult = decodeNextValue(encoded, index);
+    if (!latResult) return [];
+    latitude += latResult.value;
+    index = latResult.index;
 
-    do {
-      if (index >= encoded.length) return [];
-      byte = encoded.charCodeAt(index++) - 63;
-      result |= (byte & 0x1f) << shift;
-      shift += 5;
-    } while (byte >= 0x20);
-    latitude += result & 1 ? ~(result >> 1) : result >> 1;
-
-    result = 0;
-    shift = 0;
-    do {
-      if (index >= encoded.length) return [];
-      byte = encoded.charCodeAt(index++) - 63;
-      result |= (byte & 0x1f) << shift;
-      shift += 5;
-    } while (byte >= 0x20);
-    longitude += result & 1 ? ~(result >> 1) : result >> 1;
+    const lngResult = decodeNextValue(encoded, index);
+    if (!lngResult) return [];
+    longitude += lngResult.value;
+    index = lngResult.index;
 
     points.push({
       latitude: latitude * 1e-5,


### PR DESCRIPTION
## Summary
Refactors TASK-US-2.4.2 to resolve code quality warnings by reducing cyclomatic and cognitive complexity across MapScreen.tsx, buildingsRepository.ts, and polyline.ts

## Changes
- Converted nested logic out of MapScreen into standalone functions above the component
- Split buildAllBuildingsCache from buildingsRepository  into two functions since it was doing two jobs at once to reduce cyclomatic complexity
- Created a decodeNextValue helper function in polyline to avoid repeating the same loop twice

## How to Test
- Enter the mobile directory with `cd mobile`
- Make sure you have all the dependencies with `npm install`
- Open an emulator and run `npx expo start -c`
- Verify if the features from and up-to US-2.4.2
- Verify sonarqube is not reporting any high/medium issues

## Notes
- Modified AT_2_3.yaml maestro test as it was outdated

## Checklist
- [x] Builds/runs locally (or via Expo Go / emulator)
- [x] Meets acceptance criteria for the linked task/user story
- [x] Lint/format checks pass (if configured)
- [ ] Tests added/updated (if applicable)
- [ ] Screenshots included (for UI changes)
- [x] Ready to squash & merge
