### PR TITLE
US-3.6: [REFACTOR] Show directions with Shuttle on the map

### DIFF
--- a/mobile/__test__/BottomSheet.test.tsx
+++ b/mobile/__test__/BottomSheet.test.tsx
@@ -345,6 +345,8 @@ describe('BottomSheet', () => {
   const directionsServiceMock = directionsService as jest.Mocked<typeof directionsService>;
   const shuttlePlannerMock = shuttlePlannerService as jest.Mocked<typeof shuttlePlannerService>;
   const originalShuttleWeekdayDebug = process.env.EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_WEEKDAY;
+  const originalShuttleForcedPlanningTime =
+    process.env.EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_PLANNING_TIME;
   const pressAndFlush = async (node: any) => {
     await act(async () => {
       fireEvent.press(node);
@@ -356,6 +358,7 @@ describe('BottomSheet', () => {
     jest.clearAllMocks();
     jest.useRealTimers();
     delete process.env.EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_WEEKDAY;
+    delete process.env.EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_PLANNING_TIME;
     directionsServiceMock.fetchOutdoorDirections.mockImplementation(
       () => new Promise(() => undefined),
     );
@@ -376,6 +379,11 @@ describe('BottomSheet', () => {
       delete process.env.EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_WEEKDAY;
     } else {
       process.env.EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_WEEKDAY = originalShuttleWeekdayDebug;
+    }
+    if (originalShuttleForcedPlanningTime === undefined) {
+      delete process.env.EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_PLANNING_TIME;
+    } else {
+      process.env.EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_PLANNING_TIME = originalShuttleForcedPlanningTime;
     }
     jest.useRealTimers();
   });
@@ -820,7 +828,7 @@ describe('BottomSheet', () => {
     });
   });
 
-  test('cross-campus shuttle snaps to 62% and returns to 52% for walk/car', async () => {
+  test('cross-campus shuttle keeps directions panel at 52% (same as walk/car)', async () => {
     const { getByTestId } = render(
       <BottomSlider
         {...defaultProps}
@@ -831,10 +839,13 @@ describe('BottomSheet', () => {
     );
 
     await pressAndFlush(getByTestId('on-show-directions-as-destination'));
+    await waitFor(() => {
+      expect(getByTestId('cross-campus-state').props.children).toBe('true');
+    });
 
     await pressAndFlush(getByTestId('transport-shuttle'));
     await waitFor(() => {
-      expect(mockSnapToPosition).toHaveBeenLastCalledWith('62%');
+      expect(mockSnapToPosition).toHaveBeenLastCalledWith('52%');
     });
 
     await pressAndFlush(getByTestId('transport-walk'));

--- a/mobile/__test__/BottomSheet.test.tsx
+++ b/mobile/__test__/BottomSheet.test.tsx
@@ -187,7 +187,7 @@ jest.mock('../src/components/DirectionDetails', () => {
       const showGoButton =
         hasRouteSummary &&
         (selectedMode === 'transit' || selectedMode === 'shuttle' || canStartNavigation);
-      const showShuttleCard = selectedMode === 'shuttle' && Boolean(isCrossCampusRoute);
+      const showShuttleCard = selectedMode === 'shuttle';
 
       React.useEffect(() => {
         if (!selectedTravelMode) return;
@@ -792,9 +792,9 @@ describe('BottomSheet', () => {
     });
   });
 
-  test('same-campus shuttle mode does not expose shuttle card content path', async () => {
+  test('same-campus shuttle mode shows unavailable shuttle card content path', async () => {
     const sameCampusCurrent: BuildingShape = { ...mockBuildings[0], campus: 'SGW' };
-    const { getByTestId, queryByTestId } = render(
+    const { getByTestId } = render(
       <BottomSlider
         {...defaultProps}
         ref={createRef()}
@@ -808,8 +808,15 @@ describe('BottomSheet', () => {
 
     await waitFor(() => {
       expect(getByTestId('cross-campus-state').props.children).toBe('false');
-      expect(queryByTestId('shuttle-card-state')).toBeNull();
-      expect(shuttlePlannerMock.buildShuttlePlan).not.toHaveBeenCalled();
+      expect(getByTestId('shuttle-card-state').props.children).toBe(
+        'Shuttle bus unavailable today. Try Public Transit.',
+      );
+      expect(shuttlePlannerMock.buildShuttlePlan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startCampus: 'SGW',
+          destinationCampus: 'SGW',
+        }),
+      );
     });
   });
 

--- a/mobile/__test__/BottomSheet.test.tsx
+++ b/mobile/__test__/BottomSheet.test.tsx
@@ -761,6 +761,75 @@ describe('BottomSheet', () => {
     });
   });
 
+  test('shuttle mode routes map path to pickup stop when next bus is available', async () => {
+    const passOutdoorRoute = jest.fn();
+    const shuttlePickupCoords = { latitude: 45.458317, longitude: -73.640225 };
+
+    directionsServiceMock.fetchOutdoorDirections.mockResolvedValue({
+      polyline: '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
+      distanceMeters: 450,
+      distanceText: '450 m',
+      durationSeconds: 360,
+      durationText: '6 mins',
+      bounds: null,
+    });
+    shuttlePlannerMock.buildShuttlePlan.mockReturnValueOnce({
+      direction: 'LOYOLA_TO_SGW',
+      pickup: {
+        id: 'loy-ad',
+        campus: 'LOYOLA',
+        name: 'Loyola Shuttle Stop (AD Building)',
+        coords: shuttlePickupCoords,
+      },
+      dropoff: {
+        id: 'sgw-hall',
+        campus: 'SGW',
+        name: 'SGW Shuttle Stop (Hall Building)',
+        coords: { latitude: 45.497193, longitude: -73.578985 },
+      },
+      nextDepartures: ['10:15 AM', '10:30 AM'],
+      nextDepartureDates: [],
+      nextDepartureInMinutes: 2,
+      isServiceAvailable: true,
+    });
+
+    const { getByTestId } = render(
+      <BottomSlider
+        {...defaultProps}
+        ref={createRef()}
+        selectedBuilding={mockBuildings[1]}
+        currentBuilding={mockBuildings[0]}
+        passOutdoorRoute={passOutdoorRoute}
+      />,
+    );
+
+    await pressAndFlush(getByTestId('on-show-directions-as-destination'));
+    await waitFor(() => {
+      expect(directionsServiceMock.fetchOutdoorDirections).toHaveBeenCalled();
+    });
+
+    const initialCallCount = directionsServiceMock.fetchOutdoorDirections.mock.calls.length;
+    await pressAndFlush(getByTestId('transport-shuttle'));
+
+    await waitFor(() => {
+      expect(directionsServiceMock.fetchOutdoorDirections.mock.calls.length).toBeGreaterThan(
+        initialCallCount,
+      );
+      expect(directionsServiceMock.fetchOutdoorDirections).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          mode: 'walking',
+          destination: shuttlePickupCoords,
+        }),
+      );
+      expect(passOutdoorRoute).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          encodedPolyline: '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
+          destination: shuttlePickupCoords,
+        }),
+      );
+    });
+  });
+
   test('opens shuttle schedule view from shuttle mode and returns to directions with back arrow', async () => {
     shuttlePlannerMock.buildShuttlePlan.mockReturnValue({
       direction: 'LOYOLA_TO_SGW',

--- a/mobile/__test__/BottomSheet.test.tsx
+++ b/mobile/__test__/BottomSheet.test.tsx
@@ -260,10 +260,7 @@ jest.mock('../src/components/DirectionDetails', () => {
           <TouchableOpacity testID="transport-bus" onPress={() => handleSelectMode('transit')}>
             <Text>Bus</Text>
           </TouchableOpacity>
-          <TouchableOpacity
-            testID="transport-shuttle"
-            onPress={() => handleSelectMode('shuttle')}
-          >
+          <TouchableOpacity testID="transport-shuttle" onPress={() => handleSelectMode('shuttle')}>
             <Text>Shuttle</Text>
           </TouchableOpacity>
           {showGoButton ? (

--- a/mobile/__test__/BottomSheet.test.tsx
+++ b/mobile/__test__/BottomSheet.test.tsx
@@ -180,19 +180,21 @@ jest.mock('../src/components/DirectionDetails', () => {
     shuttlePlan,
   }: any) =>
     (() => {
-      const [selectedMode, setSelectedMode] = React.useState<'walking' | 'driving' | 'transit'>(
-        'walking',
-      );
+      const [selectedMode, setSelectedMode] = React.useState<
+        'walking' | 'driving' | 'transit' | 'shuttle'
+      >('walking');
       const hasRouteSummary = Boolean(routeDurationText && routeDistanceText);
-      const showGoButton = hasRouteSummary && (selectedMode === 'transit' || canStartNavigation);
-      const showShuttleCard = selectedMode === 'transit' && Boolean(isCrossCampusRoute);
+      const showGoButton =
+        hasRouteSummary &&
+        (selectedMode === 'transit' || selectedMode === 'shuttle' || canStartNavigation);
+      const showShuttleCard = selectedMode === 'shuttle' && Boolean(isCrossCampusRoute);
 
       React.useEffect(() => {
         if (!selectedTravelMode) return;
         setSelectedMode(selectedTravelMode);
       }, [selectedTravelMode]);
 
-      const handleSelectMode = (mode: 'walking' | 'driving' | 'transit') => {
+      const handleSelectMode = (mode: 'walking' | 'driving' | 'transit' | 'shuttle') => {
         setSelectedMode(mode);
         onTravelModeChange?.(mode);
       };
@@ -204,6 +206,7 @@ jest.mock('../src/components/DirectionDetails', () => {
           return;
         }
         if (selectedMode === 'transit') onPressTransitGo?.();
+        if (selectedMode === 'shuttle') onPressShuttleSchedule?.();
       };
 
       return (
@@ -256,6 +259,12 @@ jest.mock('../src/components/DirectionDetails', () => {
           </TouchableOpacity>
           <TouchableOpacity testID="transport-bus" onPress={() => handleSelectMode('transit')}>
             <Text>Bus</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            testID="transport-shuttle"
+            onPress={() => handleSelectMode('shuttle')}
+          >
+            <Text>Shuttle</Text>
           </TouchableOpacity>
           {showGoButton ? (
             <TouchableOpacity testID="route-go-button" onPress={handleGo}>
@@ -709,7 +718,7 @@ describe('BottomSheet', () => {
     expect(getByTestId('cross-campus-state').props.children).toBe('false');
   });
 
-  test('cross-campus transit computes shuttle plan and exposes shuttle card content path', async () => {
+  test('cross-campus shuttle mode computes shuttle plan and exposes shuttle card content path', async () => {
     shuttlePlannerMock.buildShuttlePlan.mockReturnValueOnce({
       direction: 'LOYOLA_TO_SGW',
       pickup: null,
@@ -730,7 +739,7 @@ describe('BottomSheet', () => {
     );
 
     await pressAndFlush(getByTestId('on-show-directions-as-destination'));
-    await pressAndFlush(getByTestId('transport-bus'));
+    await pressAndFlush(getByTestId('transport-shuttle'));
 
     await waitFor(() => {
       expect(shuttlePlannerMock.buildShuttlePlan).toHaveBeenCalledWith(
@@ -744,7 +753,7 @@ describe('BottomSheet', () => {
     });
   });
 
-  test('opens shuttle schedule view from shuttle card and returns to directions with back arrow', async () => {
+  test('opens shuttle schedule view from shuttle mode and returns to directions with back arrow', async () => {
     shuttlePlannerMock.buildShuttlePlan.mockReturnValue({
       direction: 'LOYOLA_TO_SGW',
       pickup: null,
@@ -765,7 +774,7 @@ describe('BottomSheet', () => {
     );
 
     await pressAndFlush(getByTestId('on-show-directions-as-destination'));
-    await pressAndFlush(getByTestId('transport-bus'));
+    await pressAndFlush(getByTestId('transport-shuttle'));
     await pressAndFlush(getByTestId('shuttle-full-schedule-button'));
 
     await waitFor(() => {
@@ -783,7 +792,7 @@ describe('BottomSheet', () => {
     });
   });
 
-  test('same-campus transit does not expose shuttle card content path', async () => {
+  test('same-campus shuttle mode does not expose shuttle card content path', async () => {
     const sameCampusCurrent: BuildingShape = { ...mockBuildings[0], campus: 'SGW' };
     const { getByTestId, queryByTestId } = render(
       <BottomSlider
@@ -795,7 +804,7 @@ describe('BottomSheet', () => {
     );
 
     await pressAndFlush(getByTestId('on-show-directions-as-destination'));
-    await pressAndFlush(getByTestId('transport-bus'));
+    await pressAndFlush(getByTestId('transport-shuttle'));
 
     await waitFor(() => {
       expect(getByTestId('cross-campus-state').props.children).toBe('false');
@@ -804,7 +813,7 @@ describe('BottomSheet', () => {
     });
   });
 
-  test('cross-campus transit snaps to 62% and returns to 52% for walk/car', async () => {
+  test('cross-campus shuttle snaps to 62% and returns to 52% for walk/car', async () => {
     const { getByTestId } = render(
       <BottomSlider
         {...defaultProps}
@@ -816,7 +825,7 @@ describe('BottomSheet', () => {
 
     await pressAndFlush(getByTestId('on-show-directions-as-destination'));
 
-    await pressAndFlush(getByTestId('transport-bus'));
+    await pressAndFlush(getByTestId('transport-shuttle'));
     await waitFor(() => {
       expect(mockSnapToPosition).toHaveBeenLastCalledWith('62%');
     });
@@ -1386,7 +1395,7 @@ describe('BottomSheet', () => {
     );
 
     await pressAndFlush(getByTestId('on-show-directions-as-destination'));
-    await pressAndFlush(getByTestId('transport-bus'));
+    await pressAndFlush(getByTestId('transport-shuttle'));
 
     const shuttlePlanArgs = shuttlePlannerMock.buildShuttlePlan.mock.calls.at(-1)?.[0];
     expect(shuttlePlanArgs).toBeTruthy();
@@ -1408,7 +1417,7 @@ describe('BottomSheet', () => {
     );
 
     await pressAndFlush(getByTestId('on-show-directions-as-destination'));
-    await pressAndFlush(getByTestId('transport-bus'));
+    await pressAndFlush(getByTestId('transport-shuttle'));
 
     const shuttlePlanArgs = shuttlePlannerMock.buildShuttlePlan.mock.calls.at(-1)?.[0];
     expect(shuttlePlanArgs).toBeTruthy();
@@ -1430,7 +1439,7 @@ describe('BottomSheet', () => {
     );
 
     await pressAndFlush(getByTestId('on-show-directions-as-destination'));
-    await pressAndFlush(getByTestId('transport-bus'));
+    await pressAndFlush(getByTestId('transport-shuttle'));
 
     const shuttlePlanArgs = shuttlePlannerMock.buildShuttlePlan.mock.calls.at(-1)?.[0];
     expect(shuttlePlanArgs).toBeTruthy();

--- a/mobile/__test__/DirectionDetails.test.tsx
+++ b/mobile/__test__/DirectionDetails.test.tsx
@@ -194,10 +194,10 @@ describe('Direction Details', () => {
         shuttlePlan={{
           direction: 'LOYOLA_TO_SGW',
           pickup: {
-            id: 'loy-ad',
+            id: 'loy-sherbrooke',
             campus: 'LOYOLA',
-            name: 'Loyola Shuttle Stop (AD Building)',
-            coords: { latitude: 45.458317, longitude: -73.640225 },
+            name: 'Loyola Shuttle Stop (Sherbrooke / Terrebonne)',
+            coords: { latitude: 45.458908, longitude: -73.641169 },
           },
           dropoff: {
             id: 'sgw-hall',
@@ -297,10 +297,10 @@ describe('Direction Details', () => {
         shuttlePlan={{
           direction: 'LOYOLA_TO_SGW',
           pickup: {
-            id: 'loy-ad',
+            id: 'loy-sherbrooke',
             campus: 'LOYOLA',
-            name: 'Loyola Shuttle Stop (AD Building)',
-            coords: { latitude: 45.458317, longitude: -73.640225 },
+            name: 'Loyola Shuttle Stop (Sherbrooke / Terrebonne)',
+            coords: { latitude: 45.458908, longitude: -73.641169 },
           },
           dropoff: {
             id: 'sgw-hall',

--- a/mobile/__test__/DirectionDetails.test.tsx
+++ b/mobile/__test__/DirectionDetails.test.tsx
@@ -194,10 +194,10 @@ describe('Direction Details', () => {
         shuttlePlan={{
           direction: 'LOYOLA_TO_SGW',
           pickup: {
-            id: 'loy-sherbrooke',
+            id: 'loy-ad',
             campus: 'LOYOLA',
-            name: 'Loyola Shuttle Stop (Sherbrooke / Terrebonne)',
-            coords: { latitude: 45.458908, longitude: -73.641169 },
+            name: 'Loyola Shuttle Stop (AD Building)',
+            coords: { latitude: 45.458317, longitude: -73.640225 },
           },
           dropoff: {
             id: 'sgw-hall',
@@ -297,10 +297,10 @@ describe('Direction Details', () => {
         shuttlePlan={{
           direction: 'LOYOLA_TO_SGW',
           pickup: {
-            id: 'loy-sherbrooke',
+            id: 'loy-ad',
             campus: 'LOYOLA',
-            name: 'Loyola Shuttle Stop (Sherbrooke / Terrebonne)',
-            coords: { latitude: 45.458908, longitude: -73.641169 },
+            name: 'Loyola Shuttle Stop (AD Building)',
+            coords: { latitude: 45.458317, longitude: -73.640225 },
           },
           dropoff: {
             id: 'sgw-hall',

--- a/mobile/__test__/DirectionDetails.test.tsx
+++ b/mobile/__test__/DirectionDetails.test.tsx
@@ -221,12 +221,12 @@ describe('Direction Details', () => {
     expect(getByTestId('shuttle-next-bus-text').props.children).toContain('Next bus in 10');
     expect(queryByTestId('shuttle-pickup-text')).toBeNull();
     expect(queryByTestId('shuttle-dropoff-text')).toBeNull();
-    expect(getByTestId('route-summary-text').props.children).toBe('14 mins');
-    expect(getByTestId('route-go-button')).toBeTruthy();
+    expect(queryByTestId('route-summary-text')).toBeNull();
+    expect(queryByTestId('route-go-button')).toBeNull();
   });
 
-  test('hides shuttle card for same-campus shuttle routes', () => {
-    const { getByTestId, queryByTestId } = render(
+  test('shows Shuttle Unavailable card for same-campus shuttle routes', () => {
+    const { getByTestId } = render(
       <DirectionDetails
         startBuilding={mockBuildings[0]}
         destinationBuilding={mockBuildings[0]}
@@ -248,7 +248,11 @@ describe('Direction Details', () => {
     );
 
     fireEvent.press(getByTestId('transport-shuttle'));
-    expect(queryByTestId('shuttle-card-content')).toBeNull();
+    expect(getByTestId('shuttle-card-content')).toBeTruthy();
+    expect(getByTestId('shuttle-unavailable-text').props.children).toBe(
+      'Shuttle service not available right now. Try Public Transit.',
+    );
+    expect(getByTestId('shuttle-full-schedule-button')).toBeTruthy();
   });
 
   test('calls onPressShuttleSchedule when schedule button is pressed', () => {
@@ -280,7 +284,7 @@ describe('Direction Details', () => {
   });
 
   test('shows only unavailable message when no shuttle buses are available', () => {
-    const { getByTestId, queryByTestId, getByText } = render(
+    const { getByTestId, queryByTestId } = render(
       <DirectionDetails
         startBuilding={mockBuildings[0]}
         destinationBuilding={mockBuildings[1]}
@@ -321,7 +325,8 @@ describe('Direction Details', () => {
     expect(queryByTestId('shuttle-direction-label')).toBeNull();
     expect(queryByTestId('shuttle-pickup-text')).toBeNull();
     expect(queryByTestId('shuttle-dropoff-text')).toBeNull();
-    expect(getByText('14 mins')).toBeTruthy();
+    expect(queryByTestId('route-summary-text')).toBeNull();
+    expect(queryByTestId('route-go-button')).toBeNull();
   });
 
   test('shows loading state when route is loading', () => {

--- a/mobile/__test__/DirectionDetails.test.tsx
+++ b/mobile/__test__/DirectionDetails.test.tsx
@@ -126,12 +126,14 @@ describe('Direction Details', () => {
     const walkButton = getByTestId('transport-walk');
     const carButton = getByTestId('transport-car');
     const busButton = getByTestId('transport-bus');
+    const shuttleButton = getByTestId('transport-shuttle');
 
     // Walk button starts active
     fireEvent.press(walkButton);
     expect(walkButton.props.accessibilityState.selected).toBe(true);
     expect(carButton.props.accessibilityState.selected).toBe(false);
     expect(busButton.props.accessibilityState.selected).toBe(false);
+    expect(shuttleButton.props.accessibilityState.selected).toBe(false);
     expect(onTravelModeChange).toHaveBeenLastCalledWith('walking');
 
     // Press car button
@@ -139,6 +141,7 @@ describe('Direction Details', () => {
     expect(walkButton.props.accessibilityState.selected).toBe(false);
     expect(carButton.props.accessibilityState.selected).toBe(true);
     expect(busButton.props.accessibilityState.selected).toBe(false);
+    expect(shuttleButton.props.accessibilityState.selected).toBe(false);
     expect(onTravelModeChange).toHaveBeenLastCalledWith('driving');
 
     // Press bus button
@@ -146,12 +149,21 @@ describe('Direction Details', () => {
     expect(walkButton.props.accessibilityState.selected).toBe(false);
     expect(carButton.props.accessibilityState.selected).toBe(false);
     expect(busButton.props.accessibilityState.selected).toBe(true);
+    expect(shuttleButton.props.accessibilityState.selected).toBe(false);
     expect(onTravelModeChange).toHaveBeenLastCalledWith('transit');
-    expect(onTravelModeChange).toHaveBeenCalledTimes(3);
+
+    // Press shuttle button
+    fireEvent.press(shuttleButton);
+    expect(walkButton.props.accessibilityState.selected).toBe(false);
+    expect(carButton.props.accessibilityState.selected).toBe(false);
+    expect(busButton.props.accessibilityState.selected).toBe(false);
+    expect(shuttleButton.props.accessibilityState.selected).toBe(true);
+    expect(onTravelModeChange).toHaveBeenLastCalledWith('shuttle');
+    expect(onTravelModeChange).toHaveBeenCalledTimes(4);
   });
 
-  test('keeps only three transport options (walk, car, transit)', () => {
-    const { queryByTestId, getByTestId } = render(
+  test('renders four transport options (walk, car, transit, shuttle)', () => {
+    const { getByTestId } = render(
       <DirectionDetails
         startBuilding={mockBuildings[0]}
         destinationBuilding={mockBuildings[1]}
@@ -164,10 +176,10 @@ describe('Direction Details', () => {
     expect(getByTestId('transport-walk')).toBeTruthy();
     expect(getByTestId('transport-car')).toBeTruthy();
     expect(getByTestId('transport-bus')).toBeTruthy();
-    expect(queryByTestId('transport-shuttle')).toBeNull();
+    expect(getByTestId('transport-shuttle')).toBeTruthy();
   });
 
-  test('renders shuttle card details when transit is selected on cross-campus routes', () => {
+  test('renders shuttle card details when shuttle is selected on cross-campus routes', () => {
     const onTravelModeChange = jest.fn();
     const { getByTestId, queryByTestId } = render(
       <DirectionDetails
@@ -202,8 +214,8 @@ describe('Direction Details', () => {
       />,
     );
 
-    fireEvent.press(getByTestId('transport-bus'));
-    expect(onTravelModeChange).toHaveBeenLastCalledWith('transit');
+    fireEvent.press(getByTestId('transport-shuttle'));
+    expect(onTravelModeChange).toHaveBeenLastCalledWith('shuttle');
     expect(getByTestId('shuttle-card-content')).toBeTruthy();
     expect(getByTestId('shuttle-direction-label').props.children).toBe('LOY -> SGW');
     expect(getByTestId('shuttle-next-bus-text').props.children).toContain('Next bus in 10');
@@ -213,7 +225,7 @@ describe('Direction Details', () => {
     expect(getByTestId('route-go-button')).toBeTruthy();
   });
 
-  test('hides shuttle card for same-campus transit', () => {
+  test('hides shuttle card for same-campus shuttle routes', () => {
     const { getByTestId, queryByTestId } = render(
       <DirectionDetails
         startBuilding={mockBuildings[0]}
@@ -235,7 +247,7 @@ describe('Direction Details', () => {
       />,
     );
 
-    fireEvent.press(getByTestId('transport-bus'));
+    fireEvent.press(getByTestId('transport-shuttle'));
     expect(queryByTestId('shuttle-card-content')).toBeNull();
   });
 
@@ -262,7 +274,7 @@ describe('Direction Details', () => {
       />,
     );
 
-    fireEvent.press(getByTestId('transport-bus'));
+    fireEvent.press(getByTestId('transport-shuttle'));
     fireEvent.press(getByTestId('shuttle-full-schedule-button'));
     expect(onPressShuttleSchedule).toHaveBeenCalledTimes(1);
   });
@@ -301,7 +313,7 @@ describe('Direction Details', () => {
       />,
     );
 
-    fireEvent.press(getByTestId('transport-bus'));
+    fireEvent.press(getByTestId('transport-shuttle'));
 
     expect(getByTestId('shuttle-unavailable-text').props.children).toBe(
       'Shuttle bus unavailable today. Try Public Transit.',
@@ -596,6 +608,7 @@ describe('Direction Details', () => {
 
     expect(getByTestId('transport-walk').props.accessibilityState.selected).toBe(true);
     expect(getByTestId('transport-bus').props.accessibilityState.selected).toBe(false);
+    expect(getByTestId('transport-shuttle').props.accessibilityState.selected).toBe(false);
     expect(queryByTestId('shuttle-card-content')).toBeNull();
 
     rerender(
@@ -613,6 +626,23 @@ describe('Direction Details', () => {
     );
 
     expect(getByTestId('transport-bus').props.accessibilityState.selected).toBe(true);
+    expect(queryByTestId('shuttle-card-content')).toBeNull();
+
+    rerender(
+      <DirectionDetails
+        startBuilding={mockBuildings[0]}
+        destinationBuilding={mockBuildings[1]}
+        onClose={jest.fn()}
+        userLocation={null}
+        currentBuilding={null}
+        isCrossCampusRoute={true}
+        selectedTravelMode="shuttle"
+        routeDurationText="14 mins"
+        routeDistanceText="1.2 km"
+      />,
+    );
+
+    expect(getByTestId('transport-shuttle').props.accessibilityState.selected).toBe(true);
     expect(getByTestId('shuttle-card-content')).toBeTruthy();
   });
 
@@ -639,7 +669,7 @@ describe('Direction Details', () => {
       />,
     );
 
-    fireEvent.press(getByTestId('transport-bus'));
+    fireEvent.press(getByTestId('transport-shuttle'));
 
     expect(getByTestId('shuttle-next-bus-text').props.children).toBe('Next bus in 1 min');
     expect(getByText('SGW -> LOY')).toBeTruthy();
@@ -666,7 +696,7 @@ describe('Direction Details', () => {
       />,
     );
 
-    fireEvent.press(getByTestId('transport-bus'));
+    fireEvent.press(getByTestId('transport-shuttle'));
     expect(getByTestId('shuttle-next-bus-text').props.children).toBe('Next bus time unavailable');
   });
 
@@ -691,7 +721,7 @@ describe('Direction Details', () => {
       />,
     );
 
-    fireEvent.press(getByTestId('transport-bus'));
+    fireEvent.press(getByTestId('transport-shuttle'));
 
     expect(getByTestId('shuttle-unavailable-text').props.children).toBe(
       'Shuttle bus unavailable today. Try Public Transit.',

--- a/mobile/__test__/MapScreen.test.tsx
+++ b/mobile/__test__/MapScreen.test.tsx
@@ -527,6 +527,59 @@ describe('MapScreen', () => {
     });
   });
 
+  test('renders dotted route polyline when route requires walking', async () => {
+    const { getByTestId } = render(
+      <MapScreen
+        passSelectedBuilding={mockPassSelectedBuilding}
+        passUserLocation={mockPassUserLocation}
+        passCurrentBuilding={mockPassCurrentBuilding}
+        openBottomSheet={mockOpenBottomSheet}
+        outdoorRoute={{
+          encodedPolyline: '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
+          start: { latitude: 45.5, longitude: -73.57 },
+          destination: { latitude: 45.49, longitude: -73.58 },
+          isWalkingRoute: true,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      const routePolyline = getByTestId('route-polyline');
+      expect(routePolyline.props.lineDashPattern).toEqual([2, 10]);
+    });
+  });
+
+  test('renders mixed route segments with dotted walking and solid transit polylines', async () => {
+    const { getByTestId } = render(
+      <MapScreen
+        passSelectedBuilding={mockPassSelectedBuilding}
+        passUserLocation={mockPassUserLocation}
+        passCurrentBuilding={mockPassCurrentBuilding}
+        openBottomSheet={mockOpenBottomSheet}
+        outdoorRoute={{
+          encodedPolyline: '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
+          start: { latitude: 45.5, longitude: -73.57 },
+          destination: { latitude: 45.49, longitude: -73.58 },
+          routeSegments: [
+            {
+              encodedPolyline: '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
+              requiresWalking: true,
+            },
+            {
+              encodedPolyline: '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
+              requiresWalking: false,
+            },
+          ],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('route-polyline').props.lineDashPattern).toEqual([2, 10]);
+      expect(getByTestId('route-polyline-segment-1').props.lineDashPattern).toBeUndefined();
+    });
+  });
+
   test('skips route fitting when map ref does not expose fitToCoordinates', async () => {
     mockHasAnimateToRegion = false;
 

--- a/mobile/__test__/directionsStrategies.test.ts
+++ b/mobile/__test__/directionsStrategies.test.ts
@@ -92,10 +92,12 @@ describe('directions strategies', () => {
                     html_instructions: '<b>Walk</b> to stop',
                     distance: { text: '200 m', value: 200 },
                     duration: { text: '3 mins', value: 180 },
+                    polyline: { points: 'walk-segment' },
                   },
                   {
                     travel_mode: 'TRANSIT',
                     duration: { text: '22 mins', value: 1320 },
+                    polyline: { points: 'transit-segment' },
                     transit_details: {
                       line: {
                         short_name: '24',
@@ -138,6 +140,16 @@ describe('directions strategies', () => {
         lineColor: null,
         lineTextColor: null,
         vehicleType: 'BUS',
+      },
+    ]);
+    expect(route.routeSegments).toEqual([
+      {
+        mode: 'walking',
+        polyline: 'walk-segment',
+      },
+      {
+        mode: 'transit',
+        polyline: 'transit-segment',
       },
     ]);
   });

--- a/mobile/__test__/googleDirections.test.ts
+++ b/mobile/__test__/googleDirections.test.ts
@@ -105,10 +105,12 @@ describe('googleDirections service', () => {
                     html_instructions: '<b>Walk</b> to <b>Guy-Concordia Station</b>',
                     distance: { text: '300 m', value: 300 },
                     duration: { text: '4 mins', value: 240 },
+                    polyline: { points: 'walk-polyline' },
                   },
                   {
                     travel_mode: 'TRANSIT',
                     duration: { text: '22 mins', value: 1320 },
+                    polyline: { points: 'transit-polyline' },
                     transit_details: {
                       departure_stop: { name: 'Guy-Concordia' },
                       arrival_stop: { name: "De l'Eglise" },
@@ -162,6 +164,16 @@ describe('googleDirections service', () => {
         lineColor: '#00985F',
         lineTextColor: '#FFFFFF',
         vehicleType: 'SUBWAY',
+      },
+    ]);
+    expect(route.routeSegments).toEqual([
+      {
+        mode: 'walking',
+        polyline: 'walk-polyline',
+      },
+      {
+        mode: 'transit',
+        polyline: 'transit-polyline',
       },
     ]);
     expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('mode=transit'));

--- a/mobile/__test__/shuttlePlanner.test.ts
+++ b/mobile/__test__/shuttlePlanner.test.ts
@@ -94,7 +94,7 @@ describe('shuttlePlanner service', () => {
     expect(result.departures).toEqual([]);
   });
 
-  test('selects nearest pickup stop on the start campus when multiple stops exist', () => {
+  test('selects available pickup and dropoff stops for cross-campus route', () => {
     const result = selectPickupDropoff({
       startCampus: 'SGW',
       destinationCampus: 'LOYOLA',
@@ -242,7 +242,14 @@ describe('shuttlePlanner service', () => {
     expect(plan.nextDepartureInMinutes).toBe(0);
   });
 
-  test('selects the closest non-first stop candidate when start is nearer to another stop', () => {
+  test('selects the nearest pickup stop when multiple custom campus stops exist', () => {
+    SHUTTLE_STOPS.push({
+      id: 'sgw-custom-near',
+      campus: 'SGW',
+      name: 'SGW Shuttle Stop (Custom Near)',
+      coords: { latitude: 45.49583, longitude: -73.579385 },
+    });
+
     const result = selectPickupDropoff({
       startCampus: 'SGW',
       destinationCampus: 'LOYOLA',
@@ -250,7 +257,7 @@ describe('shuttlePlanner service', () => {
     });
 
     expect(result).not.toBeNull();
-    expect(result?.pickup.id).toBe('sgw-gm');
+    expect(result?.pickup.id).toBe('sgw-custom-near');
     expect(result?.dropoff.campus).toBe('LOYOLA');
   });
 
@@ -312,6 +319,13 @@ describe('shuttlePlanner service', () => {
   });
 
   test('rethrows unexpected stop-selection errors in buildShuttlePlan', () => {
+    SHUTTLE_STOPS.push({
+      id: 'sgw-custom-error-path',
+      campus: 'SGW',
+      name: 'SGW Shuttle Stop (Custom Error Path)',
+      coords: { latitude: 45.49583, longitude: -73.579385 },
+    });
+
     jest.spyOn(locationUtils, 'getDistanceMeters').mockImplementation(() => {
       throw new Error('DISTANCE_FAIL');
     });

--- a/mobile/__test__/shuttleStops.test.ts
+++ b/mobile/__test__/shuttleStops.test.ts
@@ -8,12 +8,12 @@ describe('shuttleStops constants', () => {
     expect(campuses.has('LOYOLA')).toBe(true);
   });
 
-  test('contains exactly two stops per campus', () => {
+  test('contains exactly one stop per campus', () => {
     const sgwStops = SHUTTLE_STOPS.filter((stop) => stop.campus === 'SGW');
     const loyolaStops = SHUTTLE_STOPS.filter((stop) => stop.campus === 'LOYOLA');
 
-    expect(sgwStops).toHaveLength(2);
-    expect(loyolaStops).toHaveLength(2);
+    expect(sgwStops).toHaveLength(1);
+    expect(loyolaStops).toHaveLength(1);
   });
 
   test('has unique stop ids and non-empty names', () => {
@@ -39,8 +39,6 @@ describe('shuttleStops constants', () => {
     const ids = new Set(SHUTTLE_STOPS.map((stop) => stop.id));
 
     expect(ids.has('sgw-hall')).toBe(true);
-    expect(ids.has('sgw-gm')).toBe(true);
-    expect(ids.has('loy-ad')).toBe(true);
     expect(ids.has('loy-sherbrooke')).toBe(true);
   });
 });

--- a/mobile/__test__/shuttleStops.test.ts
+++ b/mobile/__test__/shuttleStops.test.ts
@@ -39,6 +39,6 @@ describe('shuttleStops constants', () => {
     const ids = new Set(SHUTTLE_STOPS.map((stop) => stop.id));
 
     expect(ids.has('sgw-hall')).toBe(true);
-    expect(ids.has('loy-sherbrooke')).toBe(true);
+    expect(ids.has('loy-ad')).toBe(true);
   });
 });

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -50,7 +50,7 @@ const SHUTTLE_SCHEDULE_SNAP_POINTS = Array.from(
   (_value, index) => `${22 + index}%`,
 );
 const DIRECTIONS_PANEL_SNAP_POINT = '52%';
-const DIRECTIONS_TRANSIT_CROSS_CAMPUS_SNAP_POINT = '62%';
+const DIRECTIONS_TRANSIT_CROSS_CAMPUS_SNAP_POINT = '52%';
 const SEARCH_EXPANDED_SNAP_POINT = '82%';
 const SHUTTLE_SCHEDULE_EXPANDED_SNAP_POINT = '92%';
 
@@ -162,7 +162,18 @@ const toInternalSnapIndex = (index: number) => {
 const isShuttleWeekdayDebugEnabled = () =>
   (process.env.EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_WEEKDAY ?? '').trim().toLowerCase() === 'true';
 
+const getForcedShuttlePlanningDate = (): Date | null => {
+  const raw = (process.env.EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_PLANNING_TIME ?? '').trim();
+  if (!raw) return null;
+
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
 const getShuttlePlanningDate = (now: Date) => {
+  const forcedPlanningDate = getForcedShuttlePlanningDate();
+  if (forcedPlanningDate) return forcedPlanningDate;
+
   if (!isShuttleWeekdayDebugEnabled()) return now;
 
   const day = now.getDay();

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -204,10 +204,7 @@ const getShuttlePlanningDate = (now: Date) => {
   return now;
 };
 
-const getDirectionsPanelSnapPoint = (
-  travelMode: RoutePlannerMode,
-  isCrossCampusRoute: boolean,
-) =>
+const getDirectionsPanelSnapPoint = (travelMode: RoutePlannerMode, isCrossCampusRoute: boolean) =>
   travelMode === 'shuttle' && isCrossCampusRoute
     ? DIRECTIONS_TRANSIT_CROSS_CAMPUS_SNAP_POINT
     : DIRECTIONS_PANEL_SNAP_POINT;
@@ -507,7 +504,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       travelMode === 'shuttle' &&
       shuttlePlan?.isServiceAvailable &&
       shuttlePlan.nextDepartureInMinutes !== null
-        ? shuttlePlan.pickup?.coords ?? null
+        ? (shuttlePlan.pickup?.coords ?? null)
         : null;
     const routeDestinationCoords = shuttlePickupCoords ?? destinationCoords;
     const routeRequestMode: DirectionsTravelMode =

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -503,6 +503,15 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
     ]);
 
     const canStartNavigationFromCurrentLocation = routeStartSource === 'current';
+    const shuttlePickupCoords =
+      travelMode === 'shuttle' &&
+      shuttlePlan?.isServiceAvailable &&
+      shuttlePlan.nextDepartureInMinutes !== null
+        ? shuttlePlan.pickup?.coords ?? null
+        : null;
+    const routeDestinationCoords = shuttlePickupCoords ?? destinationCoords;
+    const routeRequestMode: DirectionsTravelMode =
+      shuttlePickupCoords !== null ? 'walking' : toDirectionsTravelMode(travelMode);
 
     useEffect(() => {
       const shouldComputeShuttlePlan =
@@ -563,8 +572,13 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
         return;
       }
       if (activeView !== 'directions') return;
+      if (travelMode === 'shuttle' && !shuttlePickupCoords) {
+        resetRouteState();
+        return;
+      }
+      const targetDestination = routeDestinationCoords;
       // Not an error state: route cannot be requested until both endpoints are available.
-      if (!startCoords || !destinationCoords) {
+      if (!startCoords || !targetDestination) {
         resetRouteState();
         return;
       }
@@ -586,8 +600,8 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
         try {
           const route = await fetchOutdoorDirections({
             origin: startCoords,
-            destination: destinationCoords,
-            mode: toDirectionsTravelMode(travelMode),
+            destination: targetDestination,
+            mode: routeRequestMode,
           });
 
           if (cancelled) return;
@@ -603,7 +617,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
           passOutdoorRoute({
             encodedPolyline: route.polyline,
             start: startCoords,
-            destination: destinationCoords,
+            destination: targetDestination,
             distanceText: route.distanceText,
             durationText: route.durationText,
             distanceMeters: route.distanceMeters,
@@ -634,9 +648,11 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
     }, [
       activeView,
       destinationBuilding?.id,
-      destinationCoords,
       passOutdoorRoute,
       resetRouteState,
+      routeDestinationCoords,
+      routeRequestMode,
+      shuttlePickupCoords,
       startBuilding?.id,
       startCoords,
       travelMode,

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -618,6 +618,11 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
             encodedPolyline: route.polyline,
             start: startCoords,
             destination: targetDestination,
+            isWalkingRoute: routeRequestMode === 'walking',
+            routeSegments: route.routeSegments?.map((segment) => ({
+              encodedPolyline: segment.polyline,
+              requiresWalking: segment.mode === 'walking',
+            })),
             distanceText: route.distanceText,
             durationText: route.durationText,
             distanceMeters: route.distanceMeters,

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -30,6 +30,7 @@ import {
   type DirectionsTravelMode,
   type TransitInstruction,
 } from '../types/Directions';
+import type { RoutePlannerMode } from '../types/SheetMode';
 import type { SharedValue } from 'react-native-reanimated';
 import { decodePolyline } from '../utils/polyline';
 import { formatEta } from '../utils/directionsFormatting';
@@ -193,12 +194,15 @@ const getShuttlePlanningDate = (now: Date) => {
 };
 
 const getDirectionsPanelSnapPoint = (
-  travelMode: DirectionsTravelMode,
+  travelMode: RoutePlannerMode,
   isCrossCampusRoute: boolean,
 ) =>
-  travelMode === 'transit' && isCrossCampusRoute
+  travelMode === 'shuttle' && isCrossCampusRoute
     ? DIRECTIONS_TRANSIT_CROSS_CAMPUS_SNAP_POINT
     : DIRECTIONS_PANEL_SNAP_POINT;
+
+const toDirectionsTravelMode = (travelMode: RoutePlannerMode): DirectionsTravelMode =>
+  travelMode === 'shuttle' ? 'transit' : travelMode;
 
 export type BottomSliderHandle = {
   open: (index?: number) => void;
@@ -258,7 +262,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
     const [routeEncodedPolyline, setRouteEncodedPolyline] = useState<string>('');
     const [navigationProgressMeters, setNavigationProgressMeters] = useState(0);
     const [routeTransitSteps, setRouteTransitSteps] = useState<TransitInstruction[]>([]);
-    const [travelMode, setTravelMode] = useState<DirectionsTravelMode>('walking');
+    const [travelMode, setTravelMode] = useState<RoutePlannerMode>('walking');
     const [shuttlePlan, setShuttlePlan] = useState<ShuttlePlan | null>(null);
     const startCampus = startBuilding?.campus ?? currentBuilding?.campus ?? null;
     const destinationCampus = destinationBuilding?.campus ?? null;
@@ -492,7 +496,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
     useEffect(() => {
       const shouldComputeShuttlePlan =
         (activeView === 'directions' || activeView === 'shuttle-schedule') &&
-        travelMode === 'transit' &&
+        travelMode === 'shuttle' &&
         isCrossCampusRoute;
 
       if (!shouldComputeShuttlePlan || !startCampus || !destinationCampus || !startCoords) {
@@ -521,16 +525,20 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
     }, [snapToDirectionsPanel]);
 
     const handleDirectionsGo = useCallback(
-      (mode: DirectionsTravelMode) => {
+      (mode: RoutePlannerMode) => {
         if (mode === 'transit') {
           showTransitPlan();
+          return;
+        }
+        if (mode === 'shuttle') {
+          showShuttleSchedule();
           return;
         }
         if (!canStartNavigationFromCurrentLocation) return;
 
         showNavigationSummary();
       },
-      [canStartNavigationFromCurrentLocation, showNavigationSummary],
+      [canStartNavigationFromCurrentLocation, showNavigationSummary, showShuttleSchedule],
     );
 
     useEffect(() => {
@@ -569,7 +577,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
           const route = await fetchOutdoorDirections({
             origin: startCoords,
             destination: destinationCoords,
-            mode: travelMode,
+            mode: toDirectionsTravelMode(travelMode),
           });
 
           if (cancelled) return;

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -496,10 +496,9 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
     useEffect(() => {
       const shouldComputeShuttlePlan =
         (activeView === 'directions' || activeView === 'shuttle-schedule') &&
-        travelMode === 'shuttle' &&
-        isCrossCampusRoute;
+        travelMode === 'shuttle';
 
-      if (!shouldComputeShuttlePlan || !startCampus || !destinationCampus || !startCoords) {
+      if (!shouldComputeShuttlePlan || !startCampus || !destinationCampus) {
         setShuttlePlan(null);
         return;
       }
@@ -508,11 +507,11 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
         buildShuttlePlan({
           startCampus,
           destinationCampus,
-          startCoords,
+          startCoords: startCoords ?? null,
           now: getShuttlePlanningDate(new Date()),
         }),
       );
-    }, [activeView, destinationCampus, isCrossCampusRoute, startCampus, startCoords, travelMode]);
+    }, [activeView, destinationCampus, startCampus, startCoords, travelMode]);
 
     const showNavigationSummary = useCallback(() => {
       setActiveView('navigation');

--- a/mobile/src/components/DirectionDetails.tsx
+++ b/mobile/src/components/DirectionDetails.tsx
@@ -90,10 +90,9 @@ export default function DirectionDetails({
   const isSelected = (mode: RoutePlannerMode) => activeMode === mode;
   const isTransitSelected = isSelected('transit');
   const isShuttleSelected = isSelected('shuttle');
-  const showShuttleCard = isShuttleSelected && isCrossCampusRoute;
+  const showShuttleCard = isShuttleSelected;
   const hasRouteSummary = Boolean(routeDistanceText && routeDurationText);
-  const showGoButton =
-    hasRouteSummary && (isTransitSelected || isShuttleSelected || canStartNavigation);
+  const showGoButton = hasRouteSummary && (isTransitSelected || canStartNavigation);
   const canPressGo = showGoButton && !isRouteLoading && !routeErrorMessage;
 
   React.useEffect(() => {
@@ -300,15 +299,39 @@ export default function DirectionDetails({
         <View testID="shuttle-card-content" style={directionDetailsStyles.shuttleCardMetaContainer}>
           <View style={directionDetailsStyles.shuttleCardContainer}>
             {!shuttlePlan ? (
-              <>
-                <View style={directionDetailsStyles.shuttleCardTopRow}>
-                  <View style={directionDetailsStyles.shuttleHeaderSpacer} />
-                  {scheduleMenuButton}
+              isCrossCampusRoute ? (
+                <>
+                  <View style={directionDetailsStyles.shuttleCardTopRow}>
+                    <View style={directionDetailsStyles.shuttleHeaderSpacer} />
+                    {scheduleMenuButton}
+                  </View>
+                  <Text testID="shuttle-loading-text" style={directionDetailsStyles.routeMetaText}>
+                    Loading shuttle schedule...
+                  </Text>
+                </>
+              ) : (
+                <View style={directionDetailsStyles.shuttleUnavailableCard}>
+                  <View style={directionDetailsStyles.shuttleUnavailableRow}>
+                    <View style={directionDetailsStyles.shuttleUnavailableIconWrap}>
+                      <Ionicons name="alert-circle-outline" size={18} color="#F4C15B" />
+                    </View>
+                    <View style={directionDetailsStyles.shuttleUnavailableTextWrap}>
+                      <Text style={directionDetailsStyles.shuttleUnavailableTitle}>
+                        Shuttle Unavailable
+                      </Text>
+                      <Text
+                        testID="shuttle-unavailable-text"
+                        style={directionDetailsStyles.shuttleUnavailableText}
+                      >
+                        {SHUTTLE_UNAVAILABLE_MESSAGE}
+                      </Text>
+                    </View>
+                    <View style={directionDetailsStyles.shuttleUnavailableButtonWrap}>
+                      {scheduleMenuButton}
+                    </View>
+                  </View>
                 </View>
-                <Text testID="shuttle-loading-text" style={directionDetailsStyles.routeMetaText}>
-                  Loading shuttle schedule...
-                </Text>
-              </>
+              )
             ) : shuttlePlan.isServiceAvailable ? (
               <>
                 <View style={directionDetailsStyles.shuttleCardTopRow}>
@@ -353,69 +376,71 @@ export default function DirectionDetails({
           </View>
         </View>
       ) : null}
-      <View style={directionDetailsStyles.routeMetaContainer}>
-        {isRouteLoading ? (
-          <Text testID="route-loading-text" style={directionDetailsStyles.routeMetaText}>
-            Loading route...
-          </Text>
-        ) : routeErrorMessage ? (
-          <Text testID="route-error-text" style={directionDetailsStyles.routeErrorText}>
-            {routeErrorMessage}
-          </Text>
-        ) : hasRouteSummary ? (
-          <View style={directionDetailsStyles.routeSummaryRow}>
-            <View style={directionDetailsStyles.routeSummaryTextWrap}>
-              <Text
-                testID="route-summary-text"
-                numberOfLines={1}
-                style={directionDetailsStyles.routePrimaryText}
-              >
-                {routeDurationText}
-              </Text>
-              <View style={directionDetailsStyles.routeSecondaryInlineRow}>
+      {!isShuttleSelected ? (
+        <View style={directionDetailsStyles.routeMetaContainer}>
+          {isRouteLoading ? (
+            <Text testID="route-loading-text" style={directionDetailsStyles.routeMetaText}>
+              Loading route...
+            </Text>
+          ) : routeErrorMessage ? (
+            <Text testID="route-error-text" style={directionDetailsStyles.routeErrorText}>
+              {routeErrorMessage}
+            </Text>
+          ) : hasRouteSummary ? (
+            <View style={directionDetailsStyles.routeSummaryRow}>
+              <View style={directionDetailsStyles.routeSummaryTextWrap}>
                 <Text
-                  testID="route-secondary-text"
+                  testID="route-summary-text"
                   numberOfLines={1}
-                  style={directionDetailsStyles.routeSecondaryText}
+                  style={directionDetailsStyles.routePrimaryText}
                 >
-                  {routeEtaText ? `${routeEtaText} ETA - ${routeDistanceText}` : routeDistanceText}
+                  {routeDurationText}
                 </Text>
-                {isCrossCampusRoute && (
-                  <>
-                    <Text style={directionDetailsStyles.routeSecondaryText}> - </Text>
-                    <View style={directionDetailsStyles.crossCampusContainer}>
-                      <Text
-                        testID="cross-campus-label"
-                        style={directionDetailsStyles.crossCampusText}
-                      >
-                        Cross-Campus
-                      </Text>
-                    </View>
-                  </>
-                )}
+                <View style={directionDetailsStyles.routeSecondaryInlineRow}>
+                  <Text
+                    testID="route-secondary-text"
+                    numberOfLines={1}
+                    style={directionDetailsStyles.routeSecondaryText}
+                  >
+                    {routeEtaText ? `${routeEtaText} ETA - ${routeDistanceText}` : routeDistanceText}
+                  </Text>
+                  {isCrossCampusRoute && (
+                    <>
+                      <Text style={directionDetailsStyles.routeSecondaryText}> - </Text>
+                      <View style={directionDetailsStyles.crossCampusContainer}>
+                        <Text
+                          testID="cross-campus-label"
+                          style={directionDetailsStyles.crossCampusText}
+                        >
+                          Cross-Campus
+                        </Text>
+                      </View>
+                    </>
+                  )}
+                </View>
               </View>
+              {showGoButton ? (
+                <TouchableOpacity
+                  testID="route-go-button"
+                  disabled={!canPressGo}
+                  activeOpacity={canPressGo ? 0.85 : 1}
+                  onPress={handlePressGo}
+                  style={[
+                    directionDetailsStyles.routeGoButton,
+                    !canPressGo && directionDetailsStyles.routeGoButtonDisabled,
+                  ]}
+                >
+                  <Text style={directionDetailsStyles.routeGoText}>GO</Text>
+                </TouchableOpacity>
+              ) : null}
             </View>
-            {showGoButton ? (
-              <TouchableOpacity
-                testID="route-go-button"
-                disabled={!canPressGo}
-                activeOpacity={canPressGo ? 0.85 : 1}
-                onPress={handlePressGo}
-                style={[
-                  directionDetailsStyles.routeGoButton,
-                  !canPressGo && directionDetailsStyles.routeGoButtonDisabled,
-                ]}
-              >
-                <Text style={directionDetailsStyles.routeGoText}>GO</Text>
-              </TouchableOpacity>
-            ) : null}
-          </View>
-        ) : (
-          <Text testID="route-empty-text" style={directionDetailsStyles.routeMetaText}>
-            Select start and destination to view route details.
-          </Text>
-        )}
-      </View>
+          ) : (
+            <Text testID="route-empty-text" style={directionDetailsStyles.routeMetaText}>
+              Select start and destination to view route details.
+            </Text>
+          )}
+        </View>
+      ) : null}
     </>
   );
 }

--- a/mobile/src/components/DirectionDetails.tsx
+++ b/mobile/src/components/DirectionDetails.tsx
@@ -402,7 +402,9 @@ export default function DirectionDetails({
                     numberOfLines={1}
                     style={directionDetailsStyles.routeSecondaryText}
                   >
-                    {routeEtaText ? `${routeEtaText} ETA - ${routeDistanceText}` : routeDistanceText}
+                    {routeEtaText
+                      ? `${routeEtaText} ETA - ${routeDistanceText}`
+                      : routeDistanceText}
                   </Text>
                   {isCrossCampusRoute && (
                     <>

--- a/mobile/src/components/DirectionDetails.tsx
+++ b/mobile/src/components/DirectionDetails.tsx
@@ -89,9 +89,11 @@ export default function DirectionDetails({
   const [activeMode, setActiveMode] = useState<RoutePlannerMode>(selectedTravelMode ?? 'walking');
   const isSelected = (mode: RoutePlannerMode) => activeMode === mode;
   const isTransitSelected = isSelected('transit');
-  const showShuttleCard = isTransitSelected && isCrossCampusRoute;
+  const isShuttleSelected = isSelected('shuttle');
+  const showShuttleCard = isShuttleSelected && isCrossCampusRoute;
   const hasRouteSummary = Boolean(routeDistanceText && routeDurationText);
-  const showGoButton = hasRouteSummary && (isTransitSelected || canStartNavigation);
+  const showGoButton =
+    hasRouteSummary && (isTransitSelected || isShuttleSelected || canStartNavigation);
   const canPressGo = showGoButton && !isRouteLoading && !routeErrorMessage;
 
   React.useEffect(() => {
@@ -114,6 +116,11 @@ export default function DirectionDetails({
     onTravelModeChange?.('transit');
   };
 
+  const handleSelectShuttle = () => {
+    setActiveMode('shuttle');
+    onTravelModeChange?.('shuttle');
+  };
+
   const handlePressGo = () => {
     const selectedMode: RoutePlannerMode = activeMode;
     const isNavigationMode = selectedMode === 'walking' || selectedMode === 'driving';
@@ -123,6 +130,11 @@ export default function DirectionDetails({
 
     if (selectedMode === 'transit' && !onPressGo) {
       onPressTransitGo?.();
+      return;
+    }
+
+    if (selectedMode === 'shuttle' && !onPressGo) {
+      onPressShuttleSchedule?.();
       return;
     }
 
@@ -260,6 +272,21 @@ export default function DirectionDetails({
               isSelected('transit') && directionDetailsStyles.activeTransportationButton,
             ]}
             onPress={handleSelectTransit}
+          >
+            <Ionicons
+              name="train-outline"
+              size={30}
+              style={directionDetailsStyles.transportationIcon}
+            />
+          </TouchableOpacity>
+          <TouchableOpacity
+            testID="transport-shuttle"
+            accessibilityState={{ selected: isSelected('shuttle') }}
+            style={[
+              directionDetailsStyles.transportationButton,
+              isSelected('shuttle') && directionDetailsStyles.activeTransportationButton,
+            ]}
+            onPress={handleSelectShuttle}
           >
             <Ionicons
               name="bus-outline"

--- a/mobile/src/constants/shuttleStops.ts
+++ b/mobile/src/constants/shuttleStops.ts
@@ -17,9 +17,9 @@ export const SHUTTLE_STOPS: ShuttleStop[] = [
     coords: { latitude: 45.497193, longitude: -73.578985 },
   },
   {
-    id: 'loy-sherbrooke',
+    id: 'loy-ad',
     campus: 'LOYOLA',
-    name: 'Loyola Shuttle Stop (Sherbrooke / Terrebonne)',
-    coords: { latitude: 45.458908, longitude: -73.641169 },
+    name: 'Loyola Shuttle Stop (AD Building)',
+    coords: { latitude: 45.458317, longitude: -73.640225 },
   },
 ];

--- a/mobile/src/constants/shuttleStops.ts
+++ b/mobile/src/constants/shuttleStops.ts
@@ -17,18 +17,6 @@ export const SHUTTLE_STOPS: ShuttleStop[] = [
     coords: { latitude: 45.497193, longitude: -73.578985 },
   },
   {
-    id: 'sgw-gm',
-    campus: 'SGW',
-    name: 'SGW Shuttle Stop (Guy / De Maisonneuve)',
-    coords: { latitude: 45.49583, longitude: -73.579385 },
-  },
-  {
-    id: 'loy-ad',
-    campus: 'LOYOLA',
-    name: 'Loyola Shuttle Stop (AD Building)',
-    coords: { latitude: 45.458317, longitude: -73.640225 },
-  },
-  {
     id: 'loy-sherbrooke',
     campus: 'LOYOLA',
     name: 'Loyola Shuttle Stop (Sherbrooke / Terrebonne)',

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -44,6 +44,7 @@ const ROUTE_FIT_TOP_PADDING = 110;
 
 const ROUTE_LINE_COLOR = '#0472f8';
 const ROUTE_LINE_WIDTH = 6;
+const WALKING_DOT_PATTERN = [2, 10];
 
 const toUserCoords = (pos: Location.LocationObject): UserCoords => ({
   latitude: pos.coords.latitude,
@@ -266,11 +267,30 @@ export default function MapScreen({
         : { strokeColor: ROUTE_LINE_COLOR },
     [],
   );
+  const routePolylineSegments = useMemo(() => {
+    if (!outdoorRoute) return [];
+
+    if (outdoorRoute.routeSegments && outdoorRoute.routeSegments.length > 0) {
+      return outdoorRoute.routeSegments.map((segment, index) => ({
+        key: `segment-${index}`,
+        coordinates: decodePolyline(segment.encodedPolyline),
+        requiresWalking: segment.requiresWalking,
+      }));
+    }
+
+    return [
+      {
+        key: 'overview',
+        coordinates: decodePolyline(outdoorRoute.encodedPolyline),
+        requiresWalking: Boolean(outdoorRoute.isWalkingRoute),
+      },
+    ];
+  }, [outdoorRoute]);
   const routeCoordinates = useMemo(
-    () => decodePolyline(outdoorRoute?.encodedPolyline ?? ''),
-    [outdoorRoute?.encodedPolyline],
+    () => routePolylineSegments.flatMap((segment) => segment.coordinates),
+    [routePolylineSegments],
   );
-  const showRoute = routeCoordinates.length > 1 && Boolean(outdoorRoute);
+  const showRoute = routePolylineSegments.some((segment) => segment.coordinates.length > 1);
 
   useEffect(() => {
     if (!showRoute) return;
@@ -317,15 +337,21 @@ export default function MapScreen({
         {selectedMarker}
         {showRoute && (
           <>
-            <Polyline
-              testID="route-polyline"
-              coordinates={routeCoordinates}
-              {...routePolylineStrokeProps}
-              strokeWidth={ROUTE_LINE_WIDTH}
-              lineCap="round"
-              lineJoin="round"
-              zIndex={999}
-            />
+            {routePolylineSegments.map((segment, index) =>
+              segment.coordinates.length > 1 ? (
+                <Polyline
+                  key={segment.key}
+                  testID={index === 0 ? 'route-polyline' : `route-polyline-segment-${index}`}
+                  coordinates={segment.coordinates}
+                  {...routePolylineStrokeProps}
+                  lineDashPattern={segment.requiresWalking ? WALKING_DOT_PATTERN : undefined}
+                  strokeWidth={ROUTE_LINE_WIDTH}
+                  lineCap="round"
+                  lineJoin="round"
+                  zIndex={999}
+                />
+              ) : null,
+            )}
             <Marker
               testID="route-start-marker"
               coordinate={outdoorRoute!.start}

--- a/mobile/src/services/directions/googleDirectionsCore.ts
+++ b/mobile/src/services/directions/googleDirectionsCore.ts
@@ -1,5 +1,6 @@
 import type { LatLng } from 'react-native-maps';
 import {
+  DirectionsRouteSegment,
   DirectionsRequest,
   DirectionsRoute,
   DirectionsServiceError,
@@ -217,6 +218,32 @@ const extractTransitInstructions = (
   }, []);
 };
 
+const toRouteSegmentMode = (
+  travelMode: GoogleDirectionsStep['travel_mode'],
+): DirectionsRouteSegment['mode'] | null => {
+  if (travelMode === 'WALKING') return 'walking';
+  if (travelMode === 'DRIVING') return 'driving';
+  if (travelMode === 'TRANSIT') return 'transit';
+  return null;
+};
+
+const extractStepRouteSegments = (
+  steps: GoogleDirectionsStep[] | undefined,
+): DirectionsRouteSegment[] => {
+  if (!steps || steps.length === 0) return [];
+
+  return steps.flatMap((step) => {
+    const nestedSegments = extractStepRouteSegments(step.steps);
+    if (nestedSegments.length > 0) return nestedSegments;
+
+    const mode = toRouteSegmentMode(step.travel_mode);
+    const polyline = step.polyline?.points?.trim();
+    if (!mode || !polyline) return [];
+
+    return [{ mode, polyline }];
+  });
+};
+
 const toQueryString = (query: Record<string, string | number>) =>
   Object.entries(query)
     .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
@@ -382,9 +409,11 @@ export const fetchGoogleTransitRoute = async (
   const transitInstructions = result.legs.flatMap((leg, legIndex) =>
     extractTransitInstructions(leg.steps, legIndex),
   );
+  const routeSegments = result.legs.flatMap((leg) => extractStepRouteSegments(leg.steps));
 
   return {
     ...result.route,
     transitInstructions,
+    routeSegments: routeSegments.length > 0 ? routeSegments : undefined,
   };
 };

--- a/mobile/src/types/Directions.ts
+++ b/mobile/src/types/Directions.ts
@@ -34,6 +34,11 @@ export type TransitInstruction = {
   vehicleType?: string | null;
 };
 
+export type DirectionsRouteSegment = {
+  polyline: string;
+  mode: 'walking' | 'driving' | 'transit';
+};
+
 export type DirectionsRoute = {
   polyline: string;
   distanceMeters: number;
@@ -42,6 +47,7 @@ export type DirectionsRoute = {
   durationText: string;
   bounds: DirectionsBounds | null;
   transitInstructions?: TransitInstruction[];
+  routeSegments?: DirectionsRouteSegment[];
 };
 
 export type DirectionsErrorCode =

--- a/mobile/src/types/GoogleDirections.ts
+++ b/mobile/src/types/GoogleDirections.ts
@@ -37,6 +37,7 @@ export type GoogleDirectionsStep = {
   html_instructions?: string;
   distance?: { text?: string; value?: number };
   duration?: { text?: string; value?: number };
+  polyline?: { points?: string };
   transit_details?: GoogleTransitDetails;
   steps?: GoogleDirectionsStep[];
 };

--- a/mobile/src/types/Map.ts
+++ b/mobile/src/types/Map.ts
@@ -12,10 +12,17 @@ export type PolygonRenderItem = {
   coordinates: LatLng[];
 };
 
+export type OutdoorRouteSegment = {
+  encodedPolyline: string;
+  requiresWalking: boolean;
+};
+
 export type OutdoorRouteOverlay = {
   encodedPolyline: string;
   start: LatLng;
   destination: LatLng;
+  isWalkingRoute?: boolean;
+  routeSegments?: OutdoorRouteSegment[];
   distanceText?: string;
   durationText?: string;
   distanceMeters?: number;

--- a/mobile/src/types/SheetMode.ts
+++ b/mobile/src/types/SheetMode.ts
@@ -1,3 +1,3 @@
 export type SheetMode = 'detail' | 'search';
 
-export type RoutePlannerMode = 'walking' | 'driving' | 'transit';
+export type RoutePlannerMode = 'walking' | 'driving' | 'transit' | 'shuttle';


### PR DESCRIPTION
## Summary
Implements shuttle-routing and map-visualization improvements by promoting Shuttle to a dedicated planner mode, refining shuttle-only UX behavior, and rendering walking-required route segments as dotted lines for better wayfinding clarity.

## Changes
- Refactored route planner modes to add a dedicated `shuttle` option (separate from `transit`) and wired mode-specific behavior in `DirectionDetails` and `BottomSheet`.
- Updated shuttle UX logic:
  - In Shuttle mode, hide transit summary/GO section and show shuttle card content only.
  - For non cross-campus routes, show Shuttle Unavailable card.
  - When shuttle is available, map route targets the nearest shuttle pickup stop instead of the final destination.
- Added walking-segment map styling:
  - Introduced route segment metadata from Google directions parsing.
  - Render walking segments as dotted polylines, including transit itineraries with walk-to-stop portions.
- Updated shuttle stop constants to use `loy-ad` (with current reduced stop set) and aligned all dependent tests/fixtures.
- Added temporary shuttle planning-time debug override support via env (`EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_PLANNING_TIME`) for deterministic manual testing.

## How to Test
1. Open directions for a cross-campus route and switch between `Walk`, `Car`, `Transit`, and `Shuttle`.
2. In `Shuttle` mode:
   - Verify only shuttle card content is shown (no transit summary block).
   - If shuttle is available, confirm map route goes from start location to shuttle pickup stop.
   - If not cross-campus, confirm Shuttle Unavailable card is shown.
3. In `Transit` mode with a route containing walk legs, verify map shows dotted polyline for walking portions and solid polyline for transit portions.
4. (Optional) Set `EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_PLANNING_TIME=2026-02-24T10:00:00` in `.env` and restart Expo to force an available shuttle window.

## Notes
- TASK-ID/US-ID were not provided in-thread; placeholders are included above.
- The planning-time env override is debug-only and should be blank/removed for real-time behavior.
- This PR does not add new UI controls for toggling dotted styling; behavior is automatic based on route segment mode.

## Screenshots

![shuttle](https://github.com/user-attachments/assets/6eff70d3-ca8a-42aa-a3a4-f9acd828b14f)


## Checklist
- [x] Builds/runs locally (or via Expo Go / emulator)
- [x] Meets acceptance criteria for the linked task/user story
- [x] Lint/format checks pass (if configured)
- [x] Tests added/updated (if applicable)
- [x] Screenshots included (for UI changes)
- [x] Ready to squash & merge
