### PR TITLE
TASK-3.2.4: Refactor code and address Sonar analysis findings

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -88,6 +88,17 @@ jobs:
           name: jest-coverage
           path: mobile/coverage
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install mobile dependencies
+        run: npm ci
+        working-directory: mobile
+
       - name: Analyze with SonarCloud
         uses: SonarSource/sonarcloud-github-action@v5
         env:

--- a/mobile/__test__/MapScreen.test.tsx
+++ b/mobile/__test__/MapScreen.test.tsx
@@ -558,9 +558,7 @@ describe('MapScreen', () => {
       expect(routePolyline).toBeTruthy();
       expect(routePolyline.props.strokeColor).toBe('#0472f8');
       expect(routePolyline.props.strokeWidth).toBe(6);
-      if (Platform.OS === 'ios') {
-        expect(routePolyline.props.strokeColors).toEqual(['#0472f8']);
-      }
+      expect(routePolyline.props.strokeColors).toBeUndefined();
       expect(getByTestId('route-start-marker').props.coordinate).toEqual({
         latitude: 45.5,
         longitude: -73.57,
@@ -579,7 +577,7 @@ describe('MapScreen', () => {
     });
   });
 
-  test('renders dotted route polyline when route requires walking', async () => {
+  test('renders dashed route polyline when route requires walking', async () => {
     const { getByTestId } = render(
       <MapScreen
         passSelectedBuilding={mockPassSelectedBuilding}
@@ -597,11 +595,12 @@ describe('MapScreen', () => {
 
     await waitFor(() => {
       const routePolyline = getByTestId('route-polyline');
-      expect(routePolyline.props.lineDashPattern).toEqual([2, 10]);
+      expect(routePolyline.props.lineDashPattern).toEqual([12, 8]);
+      expect(routePolyline.props.lineCap).toBe('butt');
     });
   });
 
-  test('renders mixed route segments with dotted walking and solid transit polylines', async () => {
+  test('renders mixed route segments with dashed walking and solid transit polylines', async () => {
     const { getByTestId } = render(
       <MapScreen
         passSelectedBuilding={mockPassSelectedBuilding}
@@ -627,8 +626,63 @@ describe('MapScreen', () => {
     );
 
     await waitFor(() => {
-      expect(getByTestId('route-polyline').props.lineDashPattern).toEqual([2, 10]);
+      expect(getByTestId('route-polyline').props.lineDashPattern).toEqual([12, 8]);
+      expect(getByTestId('route-polyline').props.lineCap).toBe('butt');
       expect(getByTestId('route-polyline-segment-1').props.lineDashPattern).toBeUndefined();
+      expect(getByTestId('route-polyline-segment-1').props.lineCap).toBe('round');
+    });
+  });
+
+  test('switches route polyline style cleanly between walking and driving', async () => {
+    const route = {
+      encodedPolyline: '_p~iF~ps|U_ulLnnqC_mqNvxq`@',
+      start: { latitude: 45.5, longitude: -73.57 },
+      destination: { latitude: 45.49, longitude: -73.58 },
+    };
+
+    const { getByTestId, rerender } = render(
+      <MapScreen
+        passSelectedBuilding={mockPassSelectedBuilding}
+        passUserLocation={mockPassUserLocation}
+        passCurrentBuilding={mockPassCurrentBuilding}
+        openBottomSheet={mockOpenBottomSheet}
+        outdoorRoute={{ ...route, isWalkingRoute: true }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('route-polyline').props.lineDashPattern).toEqual([12, 8]);
+      expect(getByTestId('route-polyline').props.lineCap).toBe('butt');
+    });
+
+    rerender(
+      <MapScreen
+        passSelectedBuilding={mockPassSelectedBuilding}
+        passUserLocation={mockPassUserLocation}
+        passCurrentBuilding={mockPassCurrentBuilding}
+        openBottomSheet={mockOpenBottomSheet}
+        outdoorRoute={{ ...route, isWalkingRoute: false }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('route-polyline').props.lineDashPattern).toBeUndefined();
+      expect(getByTestId('route-polyline').props.lineCap).toBe('round');
+    });
+
+    rerender(
+      <MapScreen
+        passSelectedBuilding={mockPassSelectedBuilding}
+        passUserLocation={mockPassUserLocation}
+        passCurrentBuilding={mockPassCurrentBuilding}
+        openBottomSheet={mockOpenBottomSheet}
+        outdoorRoute={{ ...route, isWalkingRoute: true }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('route-polyline').props.lineDashPattern).toEqual([12, 8]);
+      expect(getByTestId('route-polyline').props.lineCap).toBe('butt');
     });
   });
 
@@ -694,7 +748,7 @@ describe('MapScreen', () => {
       await waitFor(() => {
         const routePolyline = getByTestId('route-polyline');
         expect(routePolyline.props.strokeColor).toBe('#0472f8');
-        expect(routePolyline.props.strokeColors).toEqual(['#0472f8']);
+        expect(routePolyline.props.strokeColors).toBeUndefined();
       });
     } finally {
       restorePlatformOS();

--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -1,7 +1,12 @@
 const { expo } = require('./app.json');
 
 const googleMapsApiKey = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY;
-const baseSchemes = Array.isArray(expo.scheme) ? expo.scheme : expo.scheme ? [expo.scheme] : [];
+const baseSchemes = [];
+if (Array.isArray(expo.scheme)) {
+  baseSchemes.push(...expo.scheme);
+} else if (expo.scheme) {
+  baseSchemes.push(expo.scheme);
+}
 const scheme = Array.from(new Set([...baseSchemes, expo.android?.package].filter(Boolean)));
 
 if (!googleMapsApiKey) {
@@ -16,29 +21,29 @@ module.exports = {
   ...expo,
   scheme,
   extra: {
-    ...(expo.extra ?? {}),
+    ...expo.extra,
     eas: {
-      ...(expo.extra?.eas ?? {}),
+      ...expo.extra?.eas,
       projectId: 'd9559f2e-76d4-44c9-9aaf-65fca4a5a6c8',
     },
   },
   ios: {
     ...expo.ios,
     infoPlist: {
-      ...(expo.ios?.infoPlist ?? {}),
+      ...expo.ios?.infoPlist,
       ITSAppUsesNonExemptEncryption: false,
     },
     config: {
-      ...(expo.ios?.config ?? {}),
+      ...expo.ios?.config,
       googleMapsApiKey,
     },
   },
   android: {
     ...expo.android,
     config: {
-      ...(expo.android?.config ?? {}),
+      ...expo.android?.config,
       googleMaps: {
-        ...(expo.android?.config?.googleMaps ?? {}),
+        ...expo.android?.config?.googleMaps,
         apiKey: googleMapsApiKey,
       },
     },

--- a/mobile/eslint.config.js
+++ b/mobile/eslint.config.js
@@ -17,6 +17,8 @@ module.exports = [
       'build/**',
       'coverage/**',
       '.expo/**',
+      'ios/**',
+      'android/**',
       // keep ignoring the config file if you want:
       'eslint.config.js',
     ],

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -84,6 +84,12 @@ const App = () => {
     });
   }, [openSearchBuilding]);
 
+  const openCalendarFromMap = useCallback(() => {
+    handleOpenCalendar().catch((error) => {
+      console.warn('Failed to open calendar from map action', error);
+    });
+  }, [handleOpenCalendar]);
+
   const handleMapPress = useCallback(() => {
     bottomSheetRef.current?.closeCalendarSlider();
   }, []);
@@ -113,7 +119,7 @@ const App = () => {
           passCurrentBuilding={setCurrentBuilding}
           openBottomSheet={openBuildingDetails}
           onMapPress={handleMapPress}
-          onOpenCalendar={() => void handleOpenCalendar()}
+          onOpenCalendar={openCalendarFromMap}
           externalSelectedBuilding={selectedBuilding}
           outdoorRoute={outdoorRoute}
           bottomSheetAnimatedPosition={bottomSheetAnimatedPosition}

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -236,9 +236,14 @@ type BottomSheetProps = {
   animatedPosition?: SharedValue<number>;
 };
 
-const ROUTE_UI_VIEWS: ViewType[] = ['directions', 'transit-plan', 'shuttle-schedule', 'navigation'];
+const ROUTE_UI_VIEWS = new Set<ViewType>([
+  'directions',
+  'transit-plan',
+  'shuttle-schedule',
+  'navigation',
+]);
 
-const isRouteUiVisible = (activeView: ViewType) => ROUTE_UI_VIEWS.includes(activeView);
+const isRouteUiVisible = (activeView: ViewType) => ROUTE_UI_VIEWS.has(activeView);
 
 type RouteLoadDecision =
   | { action: 'skip' }

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -879,7 +879,9 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
         (activeView === 'directions' || activeView === 'shuttle-schedule') &&
         travelMode === 'shuttle';
 
-      if (!shouldComputeShuttlePlan || !startCampus || !destinationCampus) {
+      const canComputeShuttlePlan =
+        shouldComputeShuttlePlan && startCampus !== null && destinationCampus !== null;
+      if (!canComputeShuttlePlan) {
         setShuttlePlan(null);
         return;
       }

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -236,6 +236,315 @@ type BottomSheetProps = {
   animatedPosition?: SharedValue<number>;
 };
 
+const ROUTE_UI_VIEWS: ViewType[] = ['directions', 'transit-plan', 'shuttle-schedule', 'navigation'];
+
+const isRouteUiVisible = (activeView: ViewType) => ROUTE_UI_VIEWS.includes(activeView);
+
+type RouteLoadDecision =
+  | { action: 'skip' }
+  | { action: 'reset'; message?: string | null }
+  | { action: 'load'; origin: LatLng; destination: LatLng };
+
+const getRouteLoadDecision = ({
+  activeView,
+  travelMode,
+  shuttlePickupCoords,
+  routeDestinationCoords,
+  startCoords,
+  startBuildingId,
+  destinationBuildingId,
+}: {
+  activeView: ViewType;
+  travelMode: RoutePlannerMode;
+  shuttlePickupCoords: LatLng | null;
+  routeDestinationCoords: LatLng | null;
+  startCoords: LatLng | null;
+  startBuildingId?: string;
+  destinationBuildingId?: string;
+}): RouteLoadDecision => {
+  if (!isRouteUiVisible(activeView)) {
+    return { action: 'reset' };
+  }
+
+  if (activeView !== 'directions') {
+    return { action: 'skip' };
+  }
+
+  if (travelMode === 'shuttle' && !shuttlePickupCoords) {
+    return { action: 'reset' };
+  }
+
+  if (!startCoords || !routeDestinationCoords) {
+    return { action: 'reset' };
+  }
+
+  if (startBuildingId && destinationBuildingId && startBuildingId === destinationBuildingId) {
+    return { action: 'reset', message: 'Start and destination cannot be the same.' };
+  }
+
+  return { action: 'load', origin: startCoords, destination: routeDestinationCoords };
+};
+
+const toOutdoorRouteOverlay = (
+  route: Awaited<ReturnType<typeof fetchOutdoorDirections>>,
+  start: LatLng,
+  destination: LatLng,
+  mode: DirectionsTravelMode,
+): OutdoorRouteOverlay => ({
+  encodedPolyline: route.polyline,
+  start,
+  destination,
+  isWalkingRoute: mode === 'walking',
+  routeSegments: route.routeSegments?.map((segment) => ({
+    encodedPolyline: segment.polyline,
+    requiresWalking: segment.mode === 'walking',
+  })),
+  distanceText: route.distanceText,
+  durationText: route.durationText,
+  distanceMeters: route.distanceMeters,
+  durationSeconds: route.durationSeconds,
+});
+
+const getRouteErrorMessage = (error: unknown): string => {
+  if (error instanceof DirectionsServiceError) {
+    if (error.code === 'MISSING_API_KEY') {
+      return 'Google Directions API key is missing.';
+    }
+    if (error.code === 'NO_ROUTE') {
+      return 'No route found for this start and destination.';
+    }
+  }
+
+  return 'Unable to load route. Please try again.';
+};
+
+const renderBottomSheetContent = ({
+  isSearchActive,
+  calendarSliderMode,
+  isInternalSearch,
+  selectedCalendarIds,
+  handleReselectCalendars,
+  handleCloseUpcomingClassesSlider,
+  handleCloseCalendarSelectionSlider,
+  showUpcomingClassesSlider,
+  buildings,
+  handleInternalSearch,
+  closeSearchBuilding,
+  openCalendarSelectionAfterConnect,
+  activeView,
+  selectedBuilding,
+  closeSheet,
+  showDirections,
+  currentBuilding,
+  userLocation,
+  destinationBuilding,
+  routeTransitSteps,
+  showDirectionsPanel,
+  startBuilding,
+  shuttlePlan,
+  navigationSummary,
+  endNavigation,
+  isCrossCampusRoute,
+  isRouteLoading,
+  routeErrorMessage,
+  routeDistanceText,
+  routeDurationText,
+  routeDurationSeconds,
+  travelMode,
+  canStartNavigationFromCurrentLocation,
+  setSearchFor,
+  setTravelMode,
+  handleDirectionsGo,
+  showShuttleSchedule,
+}: {
+  isSearchActive: boolean;
+  calendarSliderMode: 'selection' | 'events' | null;
+  isInternalSearch: boolean;
+  selectedCalendarIds: string[];
+  handleReselectCalendars: () => void;
+  handleCloseUpcomingClassesSlider: () => void;
+  handleCloseCalendarSelectionSlider: () => void;
+  showUpcomingClassesSlider: (calendarIds: string[]) => void;
+  buildings: BuildingShape[];
+  handleInternalSearch: (building: BuildingShape) => void;
+  closeSearchBuilding: (building: BuildingShape) => void;
+  openCalendarSelectionAfterConnect: () => void;
+  activeView: ViewType;
+  selectedBuilding: BuildingShape | null;
+  closeSheet: () => void;
+  showDirections: (building: BuildingShape, asDestination?: boolean) => void;
+  currentBuilding: BuildingShape | null;
+  userLocation: UserCoords | null;
+  destinationBuilding: BuildingShape | null;
+  routeTransitSteps: TransitInstruction[];
+  showDirectionsPanel: () => void;
+  startBuilding: BuildingShape | null;
+  shuttlePlan: ShuttlePlan | null;
+  navigationSummary: {
+    arrivalValue: string;
+    durationStat: { value: string; label: string };
+    distanceStat: { value: string; label: string };
+  } | null;
+  endNavigation: () => void;
+  isCrossCampusRoute: boolean;
+  isRouteLoading: boolean;
+  routeErrorMessage: string | null;
+  routeDistanceText: string | null;
+  routeDurationText: string | null;
+  routeDurationSeconds: number | null;
+  travelMode: RoutePlannerMode;
+  canStartNavigationFromCurrentLocation: boolean;
+  setSearchFor: React.Dispatch<React.SetStateAction<'start' | 'destination' | null>>;
+  setTravelMode: React.Dispatch<React.SetStateAction<RoutePlannerMode>>;
+  handleDirectionsGo: (mode: RoutePlannerMode) => void;
+  showShuttleSchedule: () => void;
+}) => {
+  if (isSearchActive) {
+    if (calendarSliderMode === 'events' && !isInternalSearch) {
+      return (
+        <UpcomingClassesSlider
+          selectedCalendarIds={selectedCalendarIds}
+          onReselectCalendars={handleReselectCalendars}
+          onClose={handleCloseUpcomingClassesSlider}
+        />
+      );
+    }
+
+    if (calendarSliderMode === 'selection' && !isInternalSearch) {
+      return (
+        <CalendarSelectionSlider
+          initialSelectedCalendarIds={selectedCalendarIds}
+          onDone={showUpcomingClassesSlider}
+          onClose={handleCloseCalendarSelectionSlider}
+        />
+      );
+    }
+
+    return (
+      <SearchSheet
+        buildings={buildings}
+        onPressBuilding={isInternalSearch ? handleInternalSearch : closeSearchBuilding}
+        onCalendarConnected={openCalendarSelectionAfterConnect}
+      />
+    );
+  }
+
+  if (activeView === 'building') {
+    return (
+      <BuildingDetails
+        selectedBuilding={selectedBuilding}
+        onClose={closeSheet}
+        onShowDirections={showDirections}
+        currentBuilding={currentBuilding}
+        userLocation={userLocation}
+      />
+    );
+  }
+
+  if (activeView === 'transit-plan') {
+    return (
+      <TransitPlanDetails
+        destinationBuilding={destinationBuilding}
+        routeTransitSteps={routeTransitSteps}
+        onBack={showDirectionsPanel}
+        onClose={closeSheet}
+      />
+    );
+  }
+
+  if (activeView === 'shuttle-schedule') {
+    return (
+      <ShuttleScheduleDetails
+        startBuilding={startBuilding}
+        destinationBuilding={destinationBuilding}
+        shuttlePlan={shuttlePlan}
+        onBack={showDirectionsPanel}
+        onClose={closeSheet}
+      />
+    );
+  }
+
+  if (activeView === 'navigation') {
+    return (
+      <>
+        <View style={directionDetailsStyles.navigationSummaryCard}>
+          <View style={directionDetailsStyles.navigationSummaryRow}>
+            <View style={directionDetailsStyles.navigationSummaryStat}>
+              <Text
+                numberOfLines={1}
+                adjustsFontSizeToFit
+                style={directionDetailsStyles.navigationSummaryValue}
+              >
+                {navigationSummary?.arrivalValue ?? '--:--'}
+              </Text>
+              <Text style={directionDetailsStyles.navigationSummaryLabel}>arrival</Text>
+            </View>
+            <View style={directionDetailsStyles.navigationSummaryDivider} />
+            <View style={directionDetailsStyles.navigationSummaryStat}>
+              <Text
+                numberOfLines={1}
+                adjustsFontSizeToFit
+                style={directionDetailsStyles.navigationSummaryValue}
+              >
+                {navigationSummary?.durationStat.value ?? '--'}
+              </Text>
+              <Text style={directionDetailsStyles.navigationSummaryLabel}>
+                {navigationSummary?.durationStat.label ?? 'min'}
+              </Text>
+            </View>
+            <View style={directionDetailsStyles.navigationSummaryDivider} />
+            <View style={directionDetailsStyles.navigationSummaryStat}>
+              <Text
+                numberOfLines={1}
+                adjustsFontSizeToFit
+                style={directionDetailsStyles.navigationSummaryValue}
+              >
+                {navigationSummary?.distanceStat.value ?? '--'}
+              </Text>
+              <Text style={directionDetailsStyles.navigationSummaryLabel}>
+                {navigationSummary?.distanceStat.label ?? 'km'}
+              </Text>
+            </View>
+          </View>
+        </View>
+        <TouchableOpacity
+          testID="end-navigation-button"
+          accessibilityRole="button"
+          activeOpacity={0.88}
+          onPress={endNavigation}
+          style={directionDetailsStyles.navigationEndButton}
+        >
+          <Text style={directionDetailsStyles.navigationEndButtonText}>End Navigation</Text>
+        </TouchableOpacity>
+      </>
+    );
+  }
+
+  return (
+    <DirectionDetails
+      onClose={closeSheet}
+      startBuilding={startBuilding}
+      destinationBuilding={destinationBuilding}
+      userLocation={userLocation}
+      currentBuilding={currentBuilding}
+      isCrossCampusRoute={isCrossCampusRoute}
+      isRouteLoading={isRouteLoading}
+      routeErrorMessage={routeErrorMessage}
+      routeDistanceText={routeDistanceText}
+      routeDurationText={routeDurationText}
+      routeDurationSeconds={routeDurationSeconds}
+      selectedTravelMode={travelMode}
+      shuttlePlan={shuttlePlan}
+      canStartNavigation={canStartNavigationFromCurrentLocation}
+      onPressStart={() => setSearchFor('start')}
+      onPressDestination={() => setSearchFor('destination')}
+      onTravelModeChange={setTravelMode}
+      onPressGo={handleDirectionsGo}
+      onPressShuttleSchedule={showShuttleSchedule}
+    />
+  );
+};
+
 const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
   (
     {
@@ -608,34 +917,19 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
     );
 
     useEffect(() => {
-      // Not an error state: directions panel is not active, so route UI should be reset.
-      if (
-        activeView !== 'directions' &&
-        activeView !== 'transit-plan' &&
-        activeView !== 'shuttle-schedule' &&
-        activeView !== 'navigation'
-      ) {
-        resetRouteState();
-        return;
-      }
-      if (activeView !== 'directions') return;
-      if (travelMode === 'shuttle' && !shuttlePickupCoords) {
-        resetRouteState();
-        return;
-      }
-      const targetDestination = routeDestinationCoords;
-      // Not an error state: route cannot be requested until both endpoints are available.
-      if (!startCoords || !targetDestination) {
-        resetRouteState();
-        return;
-      }
-      // Validation error state: start and destination must be different buildings.
-      if (
-        startBuilding?.id &&
-        destinationBuilding?.id &&
-        startBuilding.id === destinationBuilding.id
-      ) {
-        resetRouteState('Start and destination cannot be the same.');
+      const routeLoadDecision = getRouteLoadDecision({
+        activeView,
+        travelMode,
+        shuttlePickupCoords,
+        routeDestinationCoords,
+        startCoords,
+        startBuildingId: startBuilding?.id,
+        destinationBuildingId: destinationBuilding?.id,
+      });
+
+      if (routeLoadDecision.action === 'skip') return;
+      if (routeLoadDecision.action === 'reset') {
+        resetRouteState(routeLoadDecision.message ?? null);
         return;
       }
 
@@ -646,8 +940,8 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
         setRouteErrorMessage(null);
         try {
           const route = await fetchOutdoorDirections({
-            origin: startCoords,
-            destination: targetDestination,
+            origin: routeLoadDecision.origin,
+            destination: routeLoadDecision.destination,
             mode: routeRequestMode,
           });
 
@@ -661,34 +955,18 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
           setNavigationProgressMeters(0);
           setRouteTransitSteps(route.transitInstructions ?? []);
           setIsRouteLoading(false);
-          passOutdoorRoute({
-            encodedPolyline: route.polyline,
-            start: startCoords,
-            destination: targetDestination,
-            isWalkingRoute: routeRequestMode === 'walking',
-            routeSegments: route.routeSegments?.map((segment) => ({
-              encodedPolyline: segment.polyline,
-              requiresWalking: segment.mode === 'walking',
-            })),
-            distanceText: route.distanceText,
-            durationText: route.durationText,
-            distanceMeters: route.distanceMeters,
-            durationSeconds: route.durationSeconds,
-          });
+          passOutdoorRoute(
+            toOutdoorRouteOverlay(
+              route,
+              routeLoadDecision.origin,
+              routeLoadDecision.destination,
+              routeRequestMode,
+            ),
+          );
         } catch (error) {
           if (cancelled) return;
           console.warn('Failed to fetch outdoor directions', error);
-          if (error instanceof DirectionsServiceError) {
-            if (error.code === 'MISSING_API_KEY') {
-              resetRouteState('Google Directions API key is missing.');
-              return;
-            }
-            if (error.code === 'NO_ROUTE') {
-              resetRouteState('No route found for this start and destination.');
-              return;
-            }
-          }
-          resetRouteState('Unable to load route. Please try again.');
+          resetRouteState(getRouteErrorMessage(error));
         }
       };
 
@@ -755,124 +1033,45 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
         onClose={handleSheetClose}
       >
         <BottomSheetView style={buildingDetailsStyles.container}>
-          {isSearchActive ? (
-            calendarSliderMode === 'events' && !isInternalSearch ? (
-              <UpcomingClassesSlider
-                selectedCalendarIds={selectedCalendarIds}
-                onReselectCalendars={handleReselectCalendars}
-                onClose={handleCloseUpcomingClassesSlider}
-              />
-            ) : calendarSliderMode === 'selection' && !isInternalSearch ? (
-              <CalendarSelectionSlider
-                initialSelectedCalendarIds={selectedCalendarIds}
-                onDone={showUpcomingClassesSlider}
-                onClose={handleCloseCalendarSelectionSlider}
-              />
-            ) : (
-              <SearchSheet
-                buildings={buildings}
-                onPressBuilding={isInternalSearch ? handleInternalSearch : closeSearchBuilding}
-                onCalendarConnected={openCalendarSelectionAfterConnect}
-              />
-            )
-          ) : activeView === 'building' ? (
-            <BuildingDetails
-              selectedBuilding={selectedBuilding}
-              onClose={closeSheet}
-              onShowDirections={showDirections}
-              currentBuilding={currentBuilding}
-              userLocation={userLocation}
-            />
-          ) : activeView === 'transit-plan' ? (
-            <TransitPlanDetails
-              destinationBuilding={destinationBuilding}
-              routeTransitSteps={routeTransitSteps}
-              onBack={showDirectionsPanel}
-              onClose={closeSheet}
-            />
-          ) : activeView === 'shuttle-schedule' ? (
-            <ShuttleScheduleDetails
-              startBuilding={startBuilding}
-              destinationBuilding={destinationBuilding}
-              shuttlePlan={shuttlePlan}
-              onBack={showDirectionsPanel}
-              onClose={closeSheet}
-            />
-          ) : activeView === 'navigation' ? (
-            <>
-              <View style={directionDetailsStyles.navigationSummaryCard}>
-                <View style={directionDetailsStyles.navigationSummaryRow}>
-                  <View style={directionDetailsStyles.navigationSummaryStat}>
-                    <Text
-                      numberOfLines={1}
-                      adjustsFontSizeToFit
-                      style={directionDetailsStyles.navigationSummaryValue}
-                    >
-                      {navigationSummary?.arrivalValue ?? '--:--'}
-                    </Text>
-                    <Text style={directionDetailsStyles.navigationSummaryLabel}>arrival</Text>
-                  </View>
-                  <View style={directionDetailsStyles.navigationSummaryDivider} />
-                  <View style={directionDetailsStyles.navigationSummaryStat}>
-                    <Text
-                      numberOfLines={1}
-                      adjustsFontSizeToFit
-                      style={directionDetailsStyles.navigationSummaryValue}
-                    >
-                      {navigationSummary?.durationStat.value ?? '--'}
-                    </Text>
-                    <Text style={directionDetailsStyles.navigationSummaryLabel}>
-                      {navigationSummary?.durationStat.label ?? 'min'}
-                    </Text>
-                  </View>
-                  <View style={directionDetailsStyles.navigationSummaryDivider} />
-                  <View style={directionDetailsStyles.navigationSummaryStat}>
-                    <Text
-                      numberOfLines={1}
-                      adjustsFontSizeToFit
-                      style={directionDetailsStyles.navigationSummaryValue}
-                    >
-                      {navigationSummary?.distanceStat.value ?? '--'}
-                    </Text>
-                    <Text style={directionDetailsStyles.navigationSummaryLabel}>
-                      {navigationSummary?.distanceStat.label ?? 'km'}
-                    </Text>
-                  </View>
-                </View>
-              </View>
-              <TouchableOpacity
-                testID="end-navigation-button"
-                accessibilityRole="button"
-                activeOpacity={0.88}
-                onPress={endNavigation}
-                style={directionDetailsStyles.navigationEndButton}
-              >
-                <Text style={directionDetailsStyles.navigationEndButtonText}>End Navigation</Text>
-              </TouchableOpacity>
-            </>
-          ) : (
-            <DirectionDetails
-              onClose={closeSheet}
-              startBuilding={startBuilding}
-              destinationBuilding={destinationBuilding}
-              userLocation={userLocation}
-              currentBuilding={currentBuilding}
-              isCrossCampusRoute={isCrossCampusRoute}
-              isRouteLoading={isRouteLoading}
-              routeErrorMessage={routeErrorMessage}
-              routeDistanceText={routeDistanceText}
-              routeDurationText={routeDurationText}
-              routeDurationSeconds={routeDurationSeconds}
-              selectedTravelMode={travelMode}
-              shuttlePlan={shuttlePlan}
-              canStartNavigation={canStartNavigationFromCurrentLocation}
-              onPressStart={() => setSearchFor('start')}
-              onPressDestination={() => setSearchFor('destination')}
-              onTravelModeChange={setTravelMode}
-              onPressGo={handleDirectionsGo}
-              onPressShuttleSchedule={showShuttleSchedule}
-            />
-          )}
+          {renderBottomSheetContent({
+            isSearchActive,
+            calendarSliderMode,
+            isInternalSearch,
+            selectedCalendarIds,
+            handleReselectCalendars,
+            handleCloseUpcomingClassesSlider,
+            handleCloseCalendarSelectionSlider,
+            showUpcomingClassesSlider,
+            buildings,
+            handleInternalSearch,
+            closeSearchBuilding,
+            openCalendarSelectionAfterConnect,
+            activeView,
+            selectedBuilding,
+            closeSheet,
+            showDirections,
+            currentBuilding,
+            userLocation,
+            destinationBuilding,
+            routeTransitSteps,
+            showDirectionsPanel,
+            startBuilding,
+            shuttlePlan,
+            navigationSummary,
+            endNavigation,
+            isCrossCampusRoute,
+            isRouteLoading,
+            routeErrorMessage,
+            routeDistanceText,
+            routeDurationText,
+            routeDurationSeconds,
+            travelMode,
+            canStartNavigationFromCurrentLocation,
+            setSearchFor,
+            setTravelMode,
+            handleDirectionsGo,
+            showShuttleSchedule,
+          })}
         </BottomSheetView>
         {/**TO DO: Add in GoogleCalendar Bottom sheet view */}
       </BottomSheet>

--- a/mobile/src/components/BuildingDetails.tsx
+++ b/mobile/src/components/BuildingDetails.tsx
@@ -1,6 +1,6 @@
 //BuildingDetails.tsx loads building details upon tapping a building the user chooses.
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { View, Text, TouchableOpacity, Linking, ScrollView, Image } from 'react-native';
 import { Feather, Ionicons } from '@expo/vector-icons';
 
@@ -18,6 +18,40 @@ type BuildingDetailProps = {
   userLocation: UserCoords | null;
 };
 
+type BuildingService = {
+  id: string;
+  name: string;
+  url: string;
+};
+
+type BuildingServicesRow = {
+  id: string;
+  services: BuildingService[];
+};
+
+type BuildingImage = {
+  key: string;
+  url: string;
+};
+
+const toBuildingImages = (images: string[] | undefined): BuildingImage[] => {
+  if (!images || images.length === 0) return [];
+
+  const seenCountsByUrl = new Map<string, number>();
+  const buildingImages: BuildingImage[] = [];
+
+  for (const imageUrl of images) {
+    const currentCount = (seenCountsByUrl.get(imageUrl) ?? 0) + 1;
+    seenCountsByUrl.set(imageUrl, currentCount);
+    buildingImages.push({
+      key: `${imageUrl}#${currentCount}`,
+      url: imageUrl,
+    });
+  }
+
+  return buildingImages;
+};
+
 export default function BuildingDetails({
   selectedBuilding,
   onClose,
@@ -29,6 +63,10 @@ export default function BuildingDetails({
   const scrollViewWidth = useRef(0);
   const contentWidth = useRef(0);
   const services = selectedBuilding?.services;
+  const buildingImages = useMemo(
+    () => toBuildingImages(selectedBuilding?.images),
+    [selectedBuilding?.images],
+  );
 
   const handleDirectionsToPress = () => {
     if (selectedBuilding) {
@@ -87,11 +125,11 @@ export default function BuildingDetails({
           contentWidth.current = width;
         }}
       >
-        {selectedBuilding?.images?.map((imgUrl, index) => (
-          <View key={index} style={buildingDetailsStyles.imageWrapper}>
+        {buildingImages.map((image) => (
+          <View key={image.key} style={buildingDetailsStyles.imageWrapper}>
             <Image
               testID="carousel-image"
-              source={{ uri: imgUrl }}
+              source={{ uri: image.url }}
               style={buildingDetailsStyles.carouselImage}
             />
           </View>
@@ -100,18 +138,24 @@ export default function BuildingDetails({
     </View>
   );
 
-  const servicesSection = (buildingServices: Record<string, string>) => {
-    const entries = Object.entries(buildingServices);
-    if (entries.length === 0) return [];
+  const servicesSection = (buildingServices: Record<string, string>): BuildingServicesRow[] => {
+    const serviceEntries = Object.entries(buildingServices).map(([name, url]) => ({
+      id: `${name}-${url}`,
+      name,
+      url,
+    }));
+    if (serviceEntries.length === 0) return [];
 
-    return entries.reduce(
-      (rows, [name, url], index) => {
-        if (index % 3 === 0) rows.push([]);
-        rows[rows.length - 1].push({ name, url });
-        return rows;
-      },
-      [] as Array<Array<{ name: string; url: string }>>,
-    );
+    const rows: BuildingServicesRow[] = [];
+    for (let rowStart = 0; rowStart < serviceEntries.length; rowStart += 3) {
+      const rowServices = serviceEntries.slice(rowStart, rowStart + 3);
+      rows.push({
+        id: rowServices.map((service) => service.id).join('|'),
+        services: rowServices,
+      });
+    }
+
+    return rows;
   };
 
   return (
@@ -137,14 +181,11 @@ export default function BuildingDetails({
           <Text style={buildingDetailsStyles.servicesTitle}>Services</Text>
           <BottomSheetFlatList
             data={servicesSection(services)}
-            renderItem={({
-              item,
-              index,
-            }: ListRenderItemInfo<Array<{ name: string; url: string }>>) => (
-              <View key={index} style={buildingDetailsStyles.row}>
-                {item.map((service: { name: string; url: string }, serviceIndex: number) => (
+            renderItem={({ item }: ListRenderItemInfo<BuildingServicesRow>) => (
+              <View key={item.id} style={buildingDetailsStyles.row}>
+                {item.services.map((service) => (
                   <TouchableOpacity
-                    key={serviceIndex}
+                    key={service.id}
                     style={buildingDetailsStyles.uniqueServiceContainer}
                     onPress={() => Linking.openURL(service.url)}
                   >
@@ -153,9 +194,7 @@ export default function BuildingDetails({
                 ))}
               </View>
             )}
-            keyExtractor={(_item: Array<{ name: string; url: string }>, index: number) =>
-              index.toString()
-            }
+            keyExtractor={(item: BuildingServicesRow) => item.id}
             showsVerticalScrollIndicator={true}
           />
         </View>

--- a/mobile/src/components/CalendarSelectionCard.tsx
+++ b/mobile/src/components/CalendarSelectionCard.tsx
@@ -13,6 +13,8 @@ type CalendarSelectionCardProps = {
   onToggleCalendar: (calendarId: string) => void;
 };
 
+const CalendarOptionSeparator = () => <View style={calendarSelectionCardStyles.optionGap} />;
+
 export default function CalendarSelectionCard({
   calendars,
   selectedCalendarIds,
@@ -64,7 +66,7 @@ export default function CalendarSelectionCard({
               style={calendarSelectionCardStyles.optionsList}
               contentContainerStyle={calendarSelectionCardStyles.optionsListContent}
               keyboardShouldPersistTaps="handled"
-              ItemSeparatorComponent={() => <View style={calendarSelectionCardStyles.optionGap} />}
+              ItemSeparatorComponent={CalendarOptionSeparator}
               renderItem={({ item: calendar }) => {
                 const isSelected = selectedCalendarIdSet.has(calendar.id);
                 return (

--- a/mobile/src/components/DirectionDetails.tsx
+++ b/mobile/src/components/DirectionDetails.tsx
@@ -64,6 +64,227 @@ const inferShuttleDirection = (
   return null;
 };
 
+const getShuttleDirectionLabel = (direction: ShuttleDirection | null) =>
+  direction === 'LOYOLA_TO_SGW' ? 'LOY -> SGW' : 'SGW -> LOY';
+
+const getShuttleDepartureSummary = (nextDepartureInMinutes: number | null) => {
+  if (nextDepartureInMinutes === null) return null;
+  if (nextDepartureInMinutes <= 1) return 'Next bus in 1 min';
+  return `Next bus in ${nextDepartureInMinutes} mins`;
+};
+
+const ScheduleMenuButton = ({
+  onPress,
+}: Readonly<{
+  onPress?: () => void;
+}>) => (
+  <TouchableOpacity
+    testID="shuttle-full-schedule-button"
+    onPress={onPress}
+    style={directionDetailsStyles.shuttleScheduleButton}
+  >
+    <View style={directionDetailsStyles.shuttleScheduleIcon}>
+      <View style={directionDetailsStyles.shuttleScheduleIconRow}>
+        <View style={directionDetailsStyles.shuttleScheduleDot} />
+        <View style={directionDetailsStyles.shuttleScheduleLine} />
+      </View>
+      <View style={directionDetailsStyles.shuttleScheduleIconRow}>
+        <View style={directionDetailsStyles.shuttleScheduleDot} />
+        <View style={directionDetailsStyles.shuttleScheduleLine} />
+      </View>
+      <View style={directionDetailsStyles.shuttleScheduleIconRow}>
+        <View style={directionDetailsStyles.shuttleScheduleDot} />
+        <View style={directionDetailsStyles.shuttleScheduleLine} />
+      </View>
+    </View>
+  </TouchableOpacity>
+);
+
+const ShuttleUnavailableCard = ({
+  message,
+  scheduleMenuButton,
+}: Readonly<{
+  message: string;
+  scheduleMenuButton: React.ReactNode;
+}>) => (
+  <View style={directionDetailsStyles.shuttleUnavailableCard}>
+    <View style={directionDetailsStyles.shuttleUnavailableRow}>
+      <View style={directionDetailsStyles.shuttleUnavailableIconWrap}>
+        <Ionicons name="alert-circle-outline" size={18} color="#F4C15B" />
+      </View>
+      <View style={directionDetailsStyles.shuttleUnavailableTextWrap}>
+        <Text style={directionDetailsStyles.shuttleUnavailableTitle}>Shuttle Unavailable</Text>
+        <Text
+          testID="shuttle-unavailable-text"
+          style={directionDetailsStyles.shuttleUnavailableText}
+        >
+          {message}
+        </Text>
+      </View>
+      <View style={directionDetailsStyles.shuttleUnavailableButtonWrap}>{scheduleMenuButton}</View>
+    </View>
+  </View>
+);
+
+const renderShuttleCardBody = ({
+  isCrossCampusRoute,
+  shuttlePlan,
+  shuttleDepartureSummary,
+  shuttleDirectionLabel,
+  scheduleMenuButton,
+}: {
+  isCrossCampusRoute: boolean;
+  shuttlePlan: ShuttlePlan | null;
+  shuttleDepartureSummary: string | null;
+  shuttleDirectionLabel: string;
+  scheduleMenuButton: React.ReactNode;
+}) => {
+  if (!shuttlePlan) {
+    if (isCrossCampusRoute) {
+      return (
+        <>
+          <View style={directionDetailsStyles.shuttleCardTopRow}>
+            <View style={directionDetailsStyles.shuttleHeaderSpacer} />
+            {scheduleMenuButton}
+          </View>
+          <Text testID="shuttle-loading-text" style={directionDetailsStyles.routeMetaText}>
+            Loading shuttle schedule...
+          </Text>
+        </>
+      );
+    }
+
+    return (
+      <ShuttleUnavailableCard
+        message={SHUTTLE_UNAVAILABLE_MESSAGE}
+        scheduleMenuButton={scheduleMenuButton}
+      />
+    );
+  }
+
+  if (shuttlePlan.isServiceAvailable) {
+    return (
+      <>
+        <View style={directionDetailsStyles.shuttleCardTopRow}>
+          <Text testID="shuttle-next-bus-text" style={directionDetailsStyles.shuttlePrimaryText}>
+            {shuttleDepartureSummary ?? 'Next bus time unavailable'}
+          </Text>
+          {scheduleMenuButton}
+        </View>
+        <Text testID="shuttle-direction-label" style={directionDetailsStyles.shuttleDirectionText}>
+          {shuttleDirectionLabel}
+        </Text>
+      </>
+    );
+  }
+
+  return (
+    <ShuttleUnavailableCard
+      message={shuttlePlan.message ?? SHUTTLE_UNAVAILABLE_MESSAGE}
+      scheduleMenuButton={scheduleMenuButton}
+    />
+  );
+};
+
+const renderRouteMetaBody = ({
+  isRouteLoading,
+  routeErrorMessage,
+  hasRouteSummary,
+  routeDurationText,
+  routeDistanceText,
+  routeEtaText,
+  isCrossCampusRoute,
+  showGoButton,
+  canPressGo,
+  handlePressGo,
+}: {
+  isRouteLoading: boolean;
+  routeErrorMessage: string | null;
+  hasRouteSummary: boolean;
+  routeDurationText: string | null;
+  routeDistanceText: string | null;
+  routeEtaText: string | null;
+  isCrossCampusRoute: boolean;
+  showGoButton: boolean;
+  canPressGo: boolean;
+  handlePressGo: () => void;
+}) => {
+  if (isRouteLoading) {
+    return (
+      <Text testID="route-loading-text" style={directionDetailsStyles.routeMetaText}>
+        Loading route...
+      </Text>
+    );
+  }
+
+  if (routeErrorMessage) {
+    return (
+      <Text testID="route-error-text" style={directionDetailsStyles.routeErrorText}>
+        {routeErrorMessage}
+      </Text>
+    );
+  }
+
+  if (!hasRouteSummary) {
+    return (
+      <Text testID="route-empty-text" style={directionDetailsStyles.routeMetaText}>
+        Select start and destination to view route details.
+      </Text>
+    );
+  }
+
+  const routeSecondaryText = routeEtaText
+    ? `${routeEtaText} ETA - ${routeDistanceText}`
+    : routeDistanceText;
+
+  return (
+    <View style={directionDetailsStyles.routeSummaryRow}>
+      <View style={directionDetailsStyles.routeSummaryTextWrap}>
+        <Text
+          testID="route-summary-text"
+          numberOfLines={1}
+          style={directionDetailsStyles.routePrimaryText}
+        >
+          {routeDurationText}
+        </Text>
+        <View style={directionDetailsStyles.routeSecondaryInlineRow}>
+          <Text
+            testID="route-secondary-text"
+            numberOfLines={1}
+            style={directionDetailsStyles.routeSecondaryText}
+          >
+            {routeSecondaryText}
+          </Text>
+          {isCrossCampusRoute ? (
+            <>
+              <Text style={directionDetailsStyles.routeSecondaryText}> - </Text>
+              <View style={directionDetailsStyles.crossCampusContainer}>
+                <Text testID="cross-campus-label" style={directionDetailsStyles.crossCampusText}>
+                  Cross-Campus
+                </Text>
+              </View>
+            </>
+          ) : null}
+        </View>
+      </View>
+      {showGoButton ? (
+        <TouchableOpacity
+          testID="route-go-button"
+          disabled={!canPressGo}
+          activeOpacity={canPressGo ? 0.85 : 1}
+          onPress={handlePressGo}
+          style={[
+            directionDetailsStyles.routeGoButton,
+            !canPressGo && directionDetailsStyles.routeGoButtonDisabled,
+          ]}
+        >
+          <Text style={directionDetailsStyles.routeGoText}>GO</Text>
+        </TouchableOpacity>
+      ) : null}
+    </View>
+  );
+};
+
 export default function DirectionDetails({
   startBuilding,
   destinationBuilding,
@@ -100,24 +321,9 @@ export default function DirectionDetails({
     setActiveMode(selectedTravelMode);
   }, [selectedTravelMode]);
 
-  const handleSelectWalk = () => {
-    setActiveMode('walking');
-    onTravelModeChange?.('walking');
-  };
-
-  const handleSelectCar = () => {
-    setActiveMode('driving');
-    onTravelModeChange?.('driving');
-  };
-
-  const handleSelectTransit = () => {
-    setActiveMode('transit');
-    onTravelModeChange?.('transit');
-  };
-
-  const handleSelectShuttle = () => {
-    setActiveMode('shuttle');
-    onTravelModeChange?.('shuttle');
+  const handleSelectMode = (mode: RoutePlannerMode) => {
+    setActiveMode(mode);
+    onTravelModeChange?.(mode);
   };
 
   const handlePressGo = () => {
@@ -145,37 +351,9 @@ export default function DirectionDetails({
   const nextDepartureInMinutes = shuttlePlan?.nextDepartureInMinutes ?? null;
   const effectiveDirection =
     shuttlePlan?.direction ?? inferShuttleDirection(startBuilding, destinationBuilding);
-  const shuttleDirectionLabel =
-    effectiveDirection === 'LOYOLA_TO_SGW' ? 'LOY -> SGW' : 'SGW -> LOY';
-  const shuttleDepartureSummary =
-    nextDepartureInMinutes === null
-      ? null
-      : nextDepartureInMinutes <= 1
-        ? 'Next bus in 1 min'
-        : `Next bus in ${nextDepartureInMinutes} mins`;
-
-  const scheduleMenuButton = (
-    <TouchableOpacity
-      testID="shuttle-full-schedule-button"
-      onPress={onPressShuttleSchedule}
-      style={directionDetailsStyles.shuttleScheduleButton}
-    >
-      <View style={directionDetailsStyles.shuttleScheduleIcon}>
-        <View style={directionDetailsStyles.shuttleScheduleIconRow}>
-          <View style={directionDetailsStyles.shuttleScheduleDot} />
-          <View style={directionDetailsStyles.shuttleScheduleLine} />
-        </View>
-        <View style={directionDetailsStyles.shuttleScheduleIconRow}>
-          <View style={directionDetailsStyles.shuttleScheduleDot} />
-          <View style={directionDetailsStyles.shuttleScheduleLine} />
-        </View>
-        <View style={directionDetailsStyles.shuttleScheduleIconRow}>
-          <View style={directionDetailsStyles.shuttleScheduleDot} />
-          <View style={directionDetailsStyles.shuttleScheduleLine} />
-        </View>
-      </View>
-    </TouchableOpacity>
-  );
+  const shuttleDirectionLabel = getShuttleDirectionLabel(effectiveDirection);
+  const shuttleDepartureSummary = getShuttleDepartureSummary(nextDepartureInMinutes);
+  const scheduleMenuButton = <ScheduleMenuButton onPress={onPressShuttleSchedule} />;
 
   return (
     <>
@@ -244,7 +422,7 @@ export default function DirectionDetails({
               directionDetailsStyles.transportationButton,
               isSelected('walking') && directionDetailsStyles.activeTransportationButton,
             ]}
-            onPress={handleSelectWalk}
+            onPress={() => handleSelectMode('walking')}
           >
             <Ionicons name="walk" size={30} style={directionDetailsStyles.transportationIcon} />
           </TouchableOpacity>
@@ -255,7 +433,7 @@ export default function DirectionDetails({
               directionDetailsStyles.transportationButton,
               isSelected('driving') && directionDetailsStyles.activeTransportationButton,
             ]}
-            onPress={handleSelectCar}
+            onPress={() => handleSelectMode('driving')}
           >
             <Ionicons
               name="car-outline"
@@ -270,7 +448,7 @@ export default function DirectionDetails({
               directionDetailsStyles.transportationButton,
               isSelected('transit') && directionDetailsStyles.activeTransportationButton,
             ]}
-            onPress={handleSelectTransit}
+            onPress={() => handleSelectMode('transit')}
           >
             <Ionicons
               name="train-outline"
@@ -285,7 +463,7 @@ export default function DirectionDetails({
               directionDetailsStyles.transportationButton,
               isSelected('shuttle') && directionDetailsStyles.activeTransportationButton,
             ]}
-            onPress={handleSelectShuttle}
+            onPress={() => handleSelectMode('shuttle')}
           >
             <Ionicons
               name="bus-outline"
@@ -298,149 +476,30 @@ export default function DirectionDetails({
       {showShuttleCard ? (
         <View testID="shuttle-card-content" style={directionDetailsStyles.shuttleCardMetaContainer}>
           <View style={directionDetailsStyles.shuttleCardContainer}>
-            {!shuttlePlan ? (
-              isCrossCampusRoute ? (
-                <>
-                  <View style={directionDetailsStyles.shuttleCardTopRow}>
-                    <View style={directionDetailsStyles.shuttleHeaderSpacer} />
-                    {scheduleMenuButton}
-                  </View>
-                  <Text testID="shuttle-loading-text" style={directionDetailsStyles.routeMetaText}>
-                    Loading shuttle schedule...
-                  </Text>
-                </>
-              ) : (
-                <View style={directionDetailsStyles.shuttleUnavailableCard}>
-                  <View style={directionDetailsStyles.shuttleUnavailableRow}>
-                    <View style={directionDetailsStyles.shuttleUnavailableIconWrap}>
-                      <Ionicons name="alert-circle-outline" size={18} color="#F4C15B" />
-                    </View>
-                    <View style={directionDetailsStyles.shuttleUnavailableTextWrap}>
-                      <Text style={directionDetailsStyles.shuttleUnavailableTitle}>
-                        Shuttle Unavailable
-                      </Text>
-                      <Text
-                        testID="shuttle-unavailable-text"
-                        style={directionDetailsStyles.shuttleUnavailableText}
-                      >
-                        {SHUTTLE_UNAVAILABLE_MESSAGE}
-                      </Text>
-                    </View>
-                    <View style={directionDetailsStyles.shuttleUnavailableButtonWrap}>
-                      {scheduleMenuButton}
-                    </View>
-                  </View>
-                </View>
-              )
-            ) : shuttlePlan.isServiceAvailable ? (
-              <>
-                <View style={directionDetailsStyles.shuttleCardTopRow}>
-                  <Text
-                    testID="shuttle-next-bus-text"
-                    style={directionDetailsStyles.shuttlePrimaryText}
-                  >
-                    {shuttleDepartureSummary ?? 'Next bus time unavailable'}
-                  </Text>
-                  {scheduleMenuButton}
-                </View>
-                <Text
-                  testID="shuttle-direction-label"
-                  style={directionDetailsStyles.shuttleDirectionText}
-                >
-                  {shuttleDirectionLabel}
-                </Text>
-              </>
-            ) : (
-              <View style={directionDetailsStyles.shuttleUnavailableCard}>
-                <View style={directionDetailsStyles.shuttleUnavailableRow}>
-                  <View style={directionDetailsStyles.shuttleUnavailableIconWrap}>
-                    <Ionicons name="alert-circle-outline" size={18} color="#F4C15B" />
-                  </View>
-                  <View style={directionDetailsStyles.shuttleUnavailableTextWrap}>
-                    <Text style={directionDetailsStyles.shuttleUnavailableTitle}>
-                      Shuttle Unavailable
-                    </Text>
-                    <Text
-                      testID="shuttle-unavailable-text"
-                      style={directionDetailsStyles.shuttleUnavailableText}
-                    >
-                      {shuttlePlan?.message ?? SHUTTLE_UNAVAILABLE_MESSAGE}
-                    </Text>
-                  </View>
-                  <View style={directionDetailsStyles.shuttleUnavailableButtonWrap}>
-                    {scheduleMenuButton}
-                  </View>
-                </View>
-              </View>
-            )}
+            {renderShuttleCardBody({
+              isCrossCampusRoute,
+              shuttlePlan,
+              shuttleDepartureSummary,
+              shuttleDirectionLabel,
+              scheduleMenuButton,
+            })}
           </View>
         </View>
       ) : null}
       {!isShuttleSelected ? (
         <View style={directionDetailsStyles.routeMetaContainer}>
-          {isRouteLoading ? (
-            <Text testID="route-loading-text" style={directionDetailsStyles.routeMetaText}>
-              Loading route...
-            </Text>
-          ) : routeErrorMessage ? (
-            <Text testID="route-error-text" style={directionDetailsStyles.routeErrorText}>
-              {routeErrorMessage}
-            </Text>
-          ) : hasRouteSummary ? (
-            <View style={directionDetailsStyles.routeSummaryRow}>
-              <View style={directionDetailsStyles.routeSummaryTextWrap}>
-                <Text
-                  testID="route-summary-text"
-                  numberOfLines={1}
-                  style={directionDetailsStyles.routePrimaryText}
-                >
-                  {routeDurationText}
-                </Text>
-                <View style={directionDetailsStyles.routeSecondaryInlineRow}>
-                  <Text
-                    testID="route-secondary-text"
-                    numberOfLines={1}
-                    style={directionDetailsStyles.routeSecondaryText}
-                  >
-                    {routeEtaText
-                      ? `${routeEtaText} ETA - ${routeDistanceText}`
-                      : routeDistanceText}
-                  </Text>
-                  {isCrossCampusRoute && (
-                    <>
-                      <Text style={directionDetailsStyles.routeSecondaryText}> - </Text>
-                      <View style={directionDetailsStyles.crossCampusContainer}>
-                        <Text
-                          testID="cross-campus-label"
-                          style={directionDetailsStyles.crossCampusText}
-                        >
-                          Cross-Campus
-                        </Text>
-                      </View>
-                    </>
-                  )}
-                </View>
-              </View>
-              {showGoButton ? (
-                <TouchableOpacity
-                  testID="route-go-button"
-                  disabled={!canPressGo}
-                  activeOpacity={canPressGo ? 0.85 : 1}
-                  onPress={handlePressGo}
-                  style={[
-                    directionDetailsStyles.routeGoButton,
-                    !canPressGo && directionDetailsStyles.routeGoButtonDisabled,
-                  ]}
-                >
-                  <Text style={directionDetailsStyles.routeGoText}>GO</Text>
-                </TouchableOpacity>
-              ) : null}
-            </View>
-          ) : (
-            <Text testID="route-empty-text" style={directionDetailsStyles.routeMetaText}>
-              Select start and destination to view route details.
-            </Text>
-          )}
+          {renderRouteMetaBody({
+            isRouteLoading,
+            routeErrorMessage,
+            hasRouteSummary,
+            routeDurationText,
+            routeDistanceText,
+            routeEtaText,
+            isCrossCampusRoute,
+            showGoButton,
+            canPressGo,
+            handlePressGo,
+          })}
         </View>
       ) : null}
     </>

--- a/mobile/src/components/DirectionDetails.tsx
+++ b/mobile/src/components/DirectionDetails.tsx
@@ -486,7 +486,7 @@ export default function DirectionDetails({
           </View>
         </View>
       ) : null}
-      {!isShuttleSelected ? (
+      {isShuttleSelected ? null : (
         <View style={directionDetailsStyles.routeMetaContainer}>
           {renderRouteMetaBody({
             isRouteLoading,
@@ -501,7 +501,7 @@ export default function DirectionDetails({
             handlePressGo,
           })}
         </View>
-      ) : null}
+      )}
     </>
   );
 }

--- a/mobile/src/components/SearchSheet.tsx
+++ b/mobile/src/components/SearchSheet.tsx
@@ -5,6 +5,7 @@ import { searchBuilding } from '../styles/SearchBuilding.styles';
 import { Ionicons } from '@expo/vector-icons';
 import { BottomSheetFlatList } from '@gorhom/bottom-sheet';
 import { BuildingShape } from '../types/BuildingShape';
+import type { ListRenderItemInfo } from 'react-native';
 import {
   clearGoogleCalendarSession,
   connectGoogleCalendarAsync,
@@ -161,6 +162,30 @@ export default function SearchSheet({
   const handleSearchChange = useCallback((text?: string) => {
     setSearch(text ?? '');
   }, []);
+  const renderBuildingItem = useCallback(
+    ({ item }: ListRenderItemInfo<BuildingShape>) => (
+      <TouchableOpacity
+        style={searchBuilding.buildingPill}
+        activeOpacity={0.85}
+        onPress={() => onPressBuilding?.(item)}
+      >
+        <View style={searchBuilding.iconWrap}>
+          <Ionicons name="location-outline" size={34} color="#F5F1F2" />
+        </View>
+
+        <View style={searchBuilding.textWrap}>
+          <Text style={searchBuilding.buildingName} numberOfLines={1}>
+            {item.name}
+          </Text>
+          <Text style={searchBuilding.buildingAddress} numberOfLines={1}>
+            {'(' + item.shortCode + ') '}
+            {item.address}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    ),
+    [onPressBuilding],
+  );
 
   return (
     <View style={searchBuilding.screen}>
@@ -207,27 +232,7 @@ export default function SearchSheet({
           contentContainerStyle={searchBuilding.listContent}
           showsVerticalScrollIndicator={true}
           ListEmptyComponent={<Text style={searchBuilding.emptyText}>No buildings found</Text>}
-          renderItem={({ item }: { item: BuildingShape }) => (
-            <TouchableOpacity
-              style={searchBuilding.buildingPill}
-              activeOpacity={0.85}
-              onPress={() => onPressBuilding?.(item)}
-            >
-              <View style={searchBuilding.iconWrap}>
-                <Ionicons name="location-outline" size={34} color="#F5F1F2" />
-              </View>
-
-              <View style={searchBuilding.textWrap}>
-                <Text style={searchBuilding.buildingName} numberOfLines={1}>
-                  {item.name}
-                </Text>
-                <Text style={searchBuilding.buildingAddress} numberOfLines={1}>
-                  {'(' + item.shortCode + ') '}
-                  {item.address}
-                </Text>
-              </View>
-            </TouchableOpacity>
-          )}
+          renderItem={renderBuildingItem}
         />
       </View>
     </View>

--- a/mobile/src/components/ShuttleScheduleDetails.tsx
+++ b/mobile/src/components/ShuttleScheduleDetails.tsx
@@ -46,6 +46,16 @@ const parseScheduleTokenToMinutes = (token: string): number | null => {
   return hour * 60 + minute;
 };
 
+const getNextBusText = (nextDepartureInMinutes: number | null) => {
+  if (nextDepartureInMinutes === null) {
+    return 'Next bus time unavailable';
+  }
+  if (nextDepartureInMinutes <= 1) {
+    return 'Next bus in 1 min';
+  }
+  return `Next bus in ${nextDepartureInMinutes} mins`;
+};
+
 export default function ShuttleScheduleDetails({
   startBuilding,
   destinationBuilding,
@@ -125,11 +135,7 @@ export default function ShuttleScheduleDetails({
               testID="shuttle-schedule-next-bus-text"
               style={directionDetailsStyles.shuttlePrimaryText}
             >
-              {shuttlePlan.nextDepartureInMinutes === null
-                ? 'Next bus time unavailable'
-                : shuttlePlan.nextDepartureInMinutes <= 1
-                  ? 'Next bus in 1 min'
-                  : `Next bus in ${shuttlePlan.nextDepartureInMinutes} mins`}
+              {getNextBusText(shuttlePlan.nextDepartureInMinutes)}
             </Text>
             <Text style={directionDetailsStyles.shuttleDirectionText}>{directionLabel}</Text>
             <Text

--- a/mobile/src/components/UpcomingClassesSlider.tsx
+++ b/mobile/src/components/UpcomingClassesSlider.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useWindowDimensions } from 'react-native';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { useWindowDimensions, Text, TouchableOpacity, View } from 'react-native';
 import { BottomSheetFlatList } from '@gorhom/bottom-sheet';
 import { Ionicons } from '@expo/vector-icons';
+import type { ListRenderItemInfo } from 'react-native';
 import {
   fetchGoogleCalendarEventsAsync,
   type GoogleCalendarEventItem,
@@ -99,6 +99,25 @@ export default function UpcomingClassesSlider({
     const targetHeight = Math.round(windowHeight * 0.68);
     return Math.max(390, Math.min(targetHeight, 680));
   }, [windowHeight]);
+  const renderEventItem = useCallback(
+    ({ item: event }: ListRenderItemInfo<GoogleCalendarEventItem>) => (
+      <View
+        testID={`upcoming-class-event-${event.id}`}
+        style={upcomingClassesSliderStyles.eventItem}
+      >
+        <Ionicons name="book" size={18} color="#F5F1F2" />
+        <View style={upcomingClassesSliderStyles.eventTextWrap}>
+          <Text numberOfLines={1} style={upcomingClassesSliderStyles.eventTitleText}>
+            {event.title}
+          </Text>
+          <Text numberOfLines={1} style={upcomingClassesSliderStyles.eventMetaText}>
+            {event.location ?? 'Location not provided'}
+          </Text>
+        </View>
+      </View>
+    ),
+    [],
+  );
 
   return (
     <View style={upcomingClassesSliderStyles.container} testID="upcoming-classes-slider">
@@ -181,22 +200,7 @@ export default function UpcomingClassesSlider({
                     </Text>
                   ) : null
                 }
-                renderItem={({ item: event }: { item: GoogleCalendarEventItem }) => (
-                  <View
-                    testID={`upcoming-class-event-${event.id}`}
-                    style={upcomingClassesSliderStyles.eventItem}
-                  >
-                    <Ionicons name="book" size={18} color="#F5F1F2" />
-                    <View style={upcomingClassesSliderStyles.eventTextWrap}>
-                      <Text numberOfLines={1} style={upcomingClassesSliderStyles.eventTitleText}>
-                        {event.title}
-                      </Text>
-                      <Text numberOfLines={1} style={upcomingClassesSliderStyles.eventMetaText}>
-                        {event.location ?? 'Location not provided'}
-                      </Text>
-                    </View>
-                  </View>
-                )}
+                renderItem={renderEventItem}
               />
             </View>
           ) : null}

--- a/mobile/src/components/UpcomingClassesSlider.tsx
+++ b/mobile/src/components/UpcomingClassesSlider.tsx
@@ -93,6 +93,8 @@ export default function UpcomingClassesSlider({
   const hasMoreEvents = events.length > MAX_EVENTS_TO_RENDER;
   const isEventsListScrollable = displayedEvents.length > MAX_VISIBLE_EVENTS;
   const eventsListMaxHeight = isEventsListScrollable ? MAX_VISIBLE_EVENTS_HEIGHT : undefined;
+  const isEmptyUpcomingClasses = !isLoading && !errorMessage && events.length === 0;
+  const shouldRenderUpcomingClassesList = !isLoading && !errorMessage && events.length > 0;
   const fixedCardHeight = useMemo(() => {
     const targetHeight = Math.round(windowHeight * 0.68);
     return Math.max(390, Math.min(targetHeight, 680));
@@ -144,59 +146,59 @@ export default function UpcomingClassesSlider({
             </>
           ) : null}
 
-          {!isLoading && !errorMessage ? (
-            events.length === 0 ? (
-              <Text testID="upcoming-classes-empty" style={upcomingClassesSliderStyles.infoText}>
-                No upcoming classes were found for your selected calendars.
-              </Text>
-            ) : (
-              <View
-                style={[
-                  upcomingClassesSliderStyles.eventsViewport,
-                  eventsListMaxHeight ? { maxHeight: eventsListMaxHeight } : null,
-                ]}
-              >
-                <BottomSheetFlatList<GoogleCalendarEventItem>
-                  data={displayedEvents}
-                  keyExtractor={(event: GoogleCalendarEventItem) =>
-                    `${event.calendarId}-${event.id}-${event.startsAt}`
-                  }
-                  style={upcomingClassesSliderStyles.eventsList}
-                  contentContainerStyle={upcomingClassesSliderStyles.eventsContent}
-                  nestedScrollEnabled={true}
-                  scrollEnabled={isEventsListScrollable}
-                  showsVerticalScrollIndicator={isEventsListScrollable}
-                  keyboardShouldPersistTaps="handled"
-                  initialNumToRender={MAX_EVENTS_TO_RENDER}
-                  ListFooterComponent={
-                    hasMoreEvents ? (
-                      <Text
-                        testID="upcoming-classes-overflow-indicator"
-                        style={upcomingClassesSliderStyles.overflowIndicatorText}
-                      >
-                        ...
-                      </Text>
-                    ) : null
-                  }
-                  renderItem={({ item: event }: { item: GoogleCalendarEventItem }) => (
-                    <View
-                      testID={`upcoming-class-event-${event.id}`}
-                      style={upcomingClassesSliderStyles.eventItem}
+          {isEmptyUpcomingClasses ? (
+            <Text testID="upcoming-classes-empty" style={upcomingClassesSliderStyles.infoText}>
+              No upcoming classes were found for your selected calendars.
+            </Text>
+          ) : null}
+
+          {shouldRenderUpcomingClassesList ? (
+            <View
+              style={[
+                upcomingClassesSliderStyles.eventsViewport,
+                eventsListMaxHeight ? { maxHeight: eventsListMaxHeight } : null,
+              ]}
+            >
+              <BottomSheetFlatList<GoogleCalendarEventItem>
+                data={displayedEvents}
+                keyExtractor={(event: GoogleCalendarEventItem) =>
+                  `${event.calendarId}-${event.id}-${event.startsAt}`
+                }
+                style={upcomingClassesSliderStyles.eventsList}
+                contentContainerStyle={upcomingClassesSliderStyles.eventsContent}
+                nestedScrollEnabled={true}
+                scrollEnabled={isEventsListScrollable}
+                showsVerticalScrollIndicator={isEventsListScrollable}
+                keyboardShouldPersistTaps="handled"
+                initialNumToRender={MAX_EVENTS_TO_RENDER}
+                ListFooterComponent={
+                  hasMoreEvents ? (
+                    <Text
+                      testID="upcoming-classes-overflow-indicator"
+                      style={upcomingClassesSliderStyles.overflowIndicatorText}
                     >
-                      <Ionicons name="book" size={18} color="#F5F1F2" />
-                      <View style={upcomingClassesSliderStyles.eventTextWrap}>
-                        <Text numberOfLines={1} style={upcomingClassesSliderStyles.eventTitleText}>
-                          {event.title}
-                        </Text>
-                        <Text numberOfLines={1} style={upcomingClassesSliderStyles.eventMetaText}>
-                          {event.location ?? 'Location not provided'}
-                        </Text>
-                      </View>
+                      ...
+                    </Text>
+                  ) : null
+                }
+                renderItem={({ item: event }: { item: GoogleCalendarEventItem }) => (
+                  <View
+                    testID={`upcoming-class-event-${event.id}`}
+                    style={upcomingClassesSliderStyles.eventItem}
+                  >
+                    <Ionicons name="book" size={18} color="#F5F1F2" />
+                    <View style={upcomingClassesSliderStyles.eventTextWrap}>
+                      <Text numberOfLines={1} style={upcomingClassesSliderStyles.eventTitleText}>
+                        {event.title}
+                      </Text>
+                      <Text numberOfLines={1} style={upcomingClassesSliderStyles.eventMetaText}>
+                        {event.location ?? 'Location not provided'}
+                      </Text>
                     </View>
-                  )}
-                />
-              </View>
-            )
+                  </View>
+                )}
+              />
+            </View>
           ) : null}
         </View>
 

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useWindowDimensions, Platform, View, Text } from 'react-native';
+import { useWindowDimensions, View, Text } from 'react-native';
 import MapView, { Marker, Polygon, Polyline, PROVIDER_GOOGLE } from 'react-native-maps';
 import * as Location from 'expo-location';
 import type { SharedValue } from 'react-native-reanimated';
@@ -47,7 +47,17 @@ const ROUTE_FIT_TOP_PADDING = 110;
 
 const ROUTE_LINE_COLOR = '#0472f8';
 const ROUTE_LINE_WIDTH = 6;
-const WALKING_DOT_PATTERN = [2, 10];
+const WALKING_DASH_PATTERN = [12, 8];
+
+const toRouteSegmentKey = (
+  segmentType: 'overview' | 'segment',
+  index: number,
+  encodedPolyline: string,
+  requiresWalking: boolean,
+) => {
+  const polylineSignature = `${encodedPolyline.slice(0, 12)}-${encodedPolyline.slice(-12)}`;
+  return `${segmentType}-${index}-${requiresWalking ? 'walk' : 'solid'}-${polylineSignature}`;
+};
 
 const toUserCoords = (pos: Location.LocationObject): UserCoords => ({
   latitude: pos.coords.latitude,
@@ -289,27 +299,31 @@ export default function MapScreen({
   const showSelectedMarker = Boolean(
     selectedBuildingId && selectedBuilding && selectedMarkerCoordinate,
   );
-  const routePolylineStrokeProps = useMemo(
-    () =>
-      Platform.OS === 'ios'
-        ? { strokeColor: ROUTE_LINE_COLOR, strokeColors: [ROUTE_LINE_COLOR] }
-        : { strokeColor: ROUTE_LINE_COLOR },
-    [],
-  );
+  const routePolylineStrokeProps = useMemo(() => ({ strokeColor: ROUTE_LINE_COLOR }), []);
   const routePolylineSegments = useMemo(() => {
     if (!outdoorRoute) return [];
 
     if (outdoorRoute.routeSegments && outdoorRoute.routeSegments.length > 0) {
       return outdoorRoute.routeSegments.map((segment, index) => ({
-        key: `segment-${index}`,
+        key: toRouteSegmentKey(
+          'segment',
+          index,
+          segment.encodedPolyline,
+          Boolean(segment.requiresWalking),
+        ),
         coordinates: decodePolyline(segment.encodedPolyline),
-        requiresWalking: segment.requiresWalking,
+        requiresWalking: Boolean(segment.requiresWalking),
       }));
     }
 
     return [
       {
-        key: 'overview',
+        key: toRouteSegmentKey(
+          'overview',
+          0,
+          outdoorRoute.encodedPolyline,
+          Boolean(outdoorRoute.isWalkingRoute),
+        ),
         coordinates: decodePolyline(outdoorRoute.encodedPolyline),
         requiresWalking: Boolean(outdoorRoute.isWalkingRoute),
       },
@@ -375,9 +389,9 @@ export default function MapScreen({
                   testID={index === 0 ? 'route-polyline' : `route-polyline-segment-${index}`}
                   coordinates={segment.coordinates}
                   {...routePolylineStrokeProps}
-                  lineDashPattern={segment.requiresWalking ? WALKING_DOT_PATTERN : undefined}
+                  lineDashPattern={segment.requiresWalking ? WALKING_DASH_PATTERN : undefined}
                   strokeWidth={ROUTE_LINE_WIDTH}
-                  lineCap="round"
+                  lineCap={segment.requiresWalking ? 'butt' : 'round'}
                   lineJoin="round"
                   zIndex={999}
                 />

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -48,6 +48,7 @@ const ROUTE_FIT_TOP_PADDING = 110;
 const ROUTE_LINE_COLOR = '#0472f8';
 const ROUTE_LINE_WIDTH = 6;
 const WALKING_DASH_PATTERN = [12, 8];
+const ROUTE_POLYLINE_STROKE_PROPS = { strokeColor: ROUTE_LINE_COLOR } as const;
 
 type RoutePolylineSegment = {
   key: string;
@@ -128,6 +129,21 @@ const renderRoutePolylineElements = (
   }
 
   return polylineElements;
+};
+
+const flattenRouteCoordinates = (routePolylineSegments: RoutePolylineSegment[]) => {
+  const routeCoordinates: { latitude: number; longitude: number }[] = [];
+  for (const segment of routePolylineSegments) {
+    routeCoordinates.push(...segment.coordinates);
+  }
+  return routeCoordinates;
+};
+
+const hasRenderableRoute = (routePolylineSegments: RoutePolylineSegment[]) => {
+  for (const segment of routePolylineSegments) {
+    if (segment.coordinates.length > 1) return true;
+  }
+  return false;
 };
 
 const toUserCoords = (pos: Location.LocationObject): UserCoords => ({
@@ -225,6 +241,18 @@ const renderPolygonItem = (
   );
 };
 
+const renderPolygonItems = (
+  polygonItems: PolygonRenderItem[],
+  selectedBuildingId: string | null,
+  onPolygonPress: (item: PolygonRenderItem) => void,
+) => {
+  const elements: React.ReactElement[] = [];
+  for (const item of polygonItems) {
+    elements.push(renderPolygonItem(item, selectedBuildingId, onPolygonPress));
+  }
+  return elements;
+};
+
 const selectBuildingAtCoords = (
   coords: UserCoords,
   setCurrentBuildingId: (id: string | null) => void,
@@ -277,12 +305,21 @@ export default function MapScreen({
 
   useEffect(() => {
     let subscription: Location.LocationSubscription | null = null;
+    let isActive = true;
 
-    void initLocationTracking(setUserCoords).then((sub) => {
-      subscription = sub;
-    });
+    const startTracking = async () => {
+      const nextSubscription = await initLocationTracking(setUserCoords);
+      if (!isActive) {
+        nextSubscription?.remove();
+        return;
+      }
+      subscription = nextSubscription;
+    };
+
+    void startTracking();
 
     return () => {
+      isActive = false;
       subscription?.remove();
     };
   }, []);
@@ -357,32 +394,20 @@ export default function MapScreen({
     );
   }, [userCoords]);
 
-  const handleMapRef = useCallback((ref: any) => {
-    mapRef.current = ref;
-  }, []);
-
-  const handleMapPress = useCallback(() => {
-    onMapPress?.();
-  }, [onMapPress]);
-
   const mapInitialRegion = useMemo(() => getCampusRegion('SGW'), []);
 
   const showSelectedMarker = Boolean(
     selectedBuildingId && selectedBuilding && selectedMarkerCoordinate,
   );
-  const routePolylineStrokeProps = useMemo(() => ({ strokeColor: ROUTE_LINE_COLOR }), []);
   const routePolylineSegments = useMemo(
     () => buildRoutePolylineSegments(outdoorRoute),
     [outdoorRoute],
   );
-  const routeCoordinates = useMemo(
-    () => routePolylineSegments.flatMap((segment) => segment.coordinates),
-    [routePolylineSegments],
-  );
-  const showRoute = routePolylineSegments.some((segment) => segment.coordinates.length > 1);
+  const routeCoordinates = flattenRouteCoordinates(routePolylineSegments);
+  const showRoute = hasRenderableRoute(routePolylineSegments);
   const renderedRoutePolylines = useMemo(
-    () => renderRoutePolylineElements(routePolylineSegments, routePolylineStrokeProps),
-    [routePolylineSegments, routePolylineStrokeProps],
+    () => renderRoutePolylineElements(routePolylineSegments, ROUTE_POLYLINE_STROKE_PROPS),
+    [routePolylineSegments],
   );
 
   useEffect(() => {
@@ -406,23 +431,20 @@ export default function MapScreen({
     <Marker coordinate={selectedMarkerCoordinate!} title={selectedBuilding?.name} />
   ) : null;
 
-  const renderedPolygons = useMemo(() => {
-    const elements = [];
-    for (const item of polygonItems) {
-      elements.push(renderPolygonItem(item, selectedBuildingId, handlePolygonPress));
-    }
-    return elements;
-  }, [handlePolygonPress, polygonItems, selectedBuildingId]);
+  const renderedPolygons = useMemo(
+    () => renderPolygonItems(polygonItems, selectedBuildingId, handlePolygonPress),
+    [handlePolygonPress, polygonItems, selectedBuildingId],
+  );
 
   const mapProps = {
-    ref: handleMapRef,
+    ref: mapRef,
     testID: 'campus-map',
     style: styles.map,
     initialRegion: mapInitialRegion,
     provider: PROVIDER_GOOGLE,
     showsUserLocation: true,
     showsMyLocationButton: false,
-    onPress: handleMapPress,
+    onPress: onMapPress,
   } as const;
 
   return (

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -283,7 +283,7 @@ export default function MapScreen({
   externalSelectedBuilding,
   outdoorRoute,
   bottomSheetAnimatedPosition,
-}: MapScreenProps) {
+}: Readonly<MapScreenProps>) {
   const [selectedCampus, setSelectedCampus] = useState<Campus>('SGW');
   const [selectedBuildingId, setSelectedBuildingId] = useState<string | null>(null);
   const [userCoords, setUserCoords] = useState<UserCoords | null>(null);

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -49,6 +49,12 @@ const ROUTE_LINE_COLOR = '#0472f8';
 const ROUTE_LINE_WIDTH = 6;
 const WALKING_DASH_PATTERN = [12, 8];
 
+type RoutePolylineSegment = {
+  key: string;
+  coordinates: { latitude: number; longitude: number }[];
+  requiresWalking: boolean;
+};
+
 const toRouteSegmentKey = (
   segmentType: 'overview' | 'segment',
   index: number,
@@ -57,6 +63,71 @@ const toRouteSegmentKey = (
 ) => {
   const polylineSignature = `${encodedPolyline.slice(0, 12)}-${encodedPolyline.slice(-12)}`;
   return `${segmentType}-${index}-${requiresWalking ? 'walk' : 'solid'}-${polylineSignature}`;
+};
+
+const buildRoutePolylineSegments = (
+  outdoorRoute: OutdoorRouteOverlay | null | undefined,
+): RoutePolylineSegment[] => {
+  if (!outdoorRoute) return [];
+
+  if (outdoorRoute.routeSegments && outdoorRoute.routeSegments.length > 0) {
+    const segments: RoutePolylineSegment[] = [];
+    for (let index = 0; index < outdoorRoute.routeSegments.length; index += 1) {
+      const segment = outdoorRoute.routeSegments[index];
+      segments.push({
+        key: toRouteSegmentKey(
+          'segment',
+          index,
+          segment.encodedPolyline,
+          Boolean(segment.requiresWalking),
+        ),
+        coordinates: decodePolyline(segment.encodedPolyline),
+        requiresWalking: Boolean(segment.requiresWalking),
+      });
+    }
+    return segments;
+  }
+
+  return [
+    {
+      key: toRouteSegmentKey(
+        'overview',
+        0,
+        outdoorRoute.encodedPolyline,
+        Boolean(outdoorRoute.isWalkingRoute),
+      ),
+      coordinates: decodePolyline(outdoorRoute.encodedPolyline),
+      requiresWalking: Boolean(outdoorRoute.isWalkingRoute),
+    },
+  ];
+};
+
+const renderRoutePolylineElements = (
+  routePolylineSegments: RoutePolylineSegment[],
+  routePolylineStrokeProps: { strokeColor: string },
+) => {
+  const polylineElements: React.ReactElement[] = [];
+
+  for (let index = 0; index < routePolylineSegments.length; index += 1) {
+    const segment = routePolylineSegments[index];
+    if (segment.coordinates.length <= 1) continue;
+
+    polylineElements.push(
+      <Polyline
+        key={segment.key}
+        testID={index === 0 ? 'route-polyline' : `route-polyline-segment-${index}`}
+        coordinates={segment.coordinates}
+        {...routePolylineStrokeProps}
+        lineDashPattern={segment.requiresWalking ? WALKING_DASH_PATTERN : undefined}
+        strokeWidth={ROUTE_LINE_WIDTH}
+        lineCap={segment.requiresWalking ? 'butt' : 'round'}
+        lineJoin="round"
+        zIndex={999}
+      />,
+    );
+  }
+
+  return polylineElements;
 };
 
 const toUserCoords = (pos: Location.LocationObject): UserCoords => ({
@@ -300,40 +371,19 @@ export default function MapScreen({
     selectedBuildingId && selectedBuilding && selectedMarkerCoordinate,
   );
   const routePolylineStrokeProps = useMemo(() => ({ strokeColor: ROUTE_LINE_COLOR }), []);
-  const routePolylineSegments = useMemo(() => {
-    if (!outdoorRoute) return [];
-
-    if (outdoorRoute.routeSegments && outdoorRoute.routeSegments.length > 0) {
-      return outdoorRoute.routeSegments.map((segment, index) => ({
-        key: toRouteSegmentKey(
-          'segment',
-          index,
-          segment.encodedPolyline,
-          Boolean(segment.requiresWalking),
-        ),
-        coordinates: decodePolyline(segment.encodedPolyline),
-        requiresWalking: Boolean(segment.requiresWalking),
-      }));
-    }
-
-    return [
-      {
-        key: toRouteSegmentKey(
-          'overview',
-          0,
-          outdoorRoute.encodedPolyline,
-          Boolean(outdoorRoute.isWalkingRoute),
-        ),
-        coordinates: decodePolyline(outdoorRoute.encodedPolyline),
-        requiresWalking: Boolean(outdoorRoute.isWalkingRoute),
-      },
-    ];
-  }, [outdoorRoute]);
+  const routePolylineSegments = useMemo(
+    () => buildRoutePolylineSegments(outdoorRoute),
+    [outdoorRoute],
+  );
   const routeCoordinates = useMemo(
     () => routePolylineSegments.flatMap((segment) => segment.coordinates),
     [routePolylineSegments],
   );
   const showRoute = routePolylineSegments.some((segment) => segment.coordinates.length > 1);
+  const renderedRoutePolylines = useMemo(
+    () => renderRoutePolylineElements(routePolylineSegments, routePolylineStrokeProps),
+    [routePolylineSegments, routePolylineStrokeProps],
+  );
 
   useEffect(() => {
     if (!showRoute) return;
@@ -382,21 +432,7 @@ export default function MapScreen({
         {selectedMarker}
         {showRoute && (
           <>
-            {routePolylineSegments.map((segment, index) =>
-              segment.coordinates.length > 1 ? (
-                <Polyline
-                  key={segment.key}
-                  testID={index === 0 ? 'route-polyline' : `route-polyline-segment-${index}`}
-                  coordinates={segment.coordinates}
-                  {...routePolylineStrokeProps}
-                  lineDashPattern={segment.requiresWalking ? WALKING_DASH_PATTERN : undefined}
-                  strokeWidth={ROUTE_LINE_WIDTH}
-                  lineCap={segment.requiresWalking ? 'butt' : 'round'}
-                  lineJoin="round"
-                  zIndex={999}
-                />
-              ) : null,
-            )}
+            {renderedRoutePolylines}
             <Marker
               testID="route-start-marker"
               coordinate={outdoorRoute!.start}

--- a/mobile/src/services/directions/googleDirectionsCore.ts
+++ b/mobile/src/services/directions/googleDirectionsCore.ts
@@ -53,12 +53,12 @@ const mapStatusToErrorCode = (status: GoogleDirectionsStatus) => {
 
 const decodeHtmlEntities = (raw: string) =>
   raw
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>');
+    .replaceAll('&nbsp;', ' ')
+    .replaceAll('&amp;', '&')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>');
 
 const stripHtmlTags = (raw: string) => {
   let output = '';

--- a/mobile/src/services/directions/googleDirectionsCore.ts
+++ b/mobile/src/services/directions/googleDirectionsCore.ts
@@ -78,7 +78,7 @@ const stripHtmlTags = (raw: string) => {
 
     pendingTag += char;
     if (char === '>') {
-      if (output.length > 0 && output[output.length - 1] !== ' ') {
+      if (output.length > 0 && !output.endsWith(' ')) {
         output += ' ';
       }
       inTag = false;
@@ -340,7 +340,7 @@ const parseDirectionsRoute = (
   }
 
   const route = data.routes?.[0];
-  if (!route || !route.overview_polyline?.points) {
+  if (!route?.overview_polyline?.points) {
     throw new DirectionsServiceError('NO_ROUTE', 'No valid outdoor route was returned.');
   }
 

--- a/mobile/src/services/googleCalendarAuth.ts
+++ b/mobile/src/services/googleCalendarAuth.ts
@@ -92,7 +92,7 @@ const parseStoredSession = (value: string): GoogleCalendarSession | null => {
   if (typeof candidate.expiresAt !== 'number' || !Number.isFinite(candidate.expiresAt)) {
     return null;
   }
-  if (typeof candidate.refreshToken !== 'undefined' && !isNonEmptyString(candidate.refreshToken)) {
+  if (candidate.refreshToken !== undefined && !isNonEmptyString(candidate.refreshToken)) {
     return null;
   }
 

--- a/mobile/src/services/googleDirections.ts
+++ b/mobile/src/services/googleDirections.ts
@@ -1,8 +1,7 @@
 import type { DirectionsRequest, DirectionsRoute } from '../types/Directions';
-import { buildDirectionsApiUrl } from './directions/googleDirectionsCore';
 import { getDirectionsStrategy } from './directions/strategies/directionsStrategyFactory';
 
-export { buildDirectionsApiUrl };
+export { buildDirectionsApiUrl } from './directions/googleDirectionsCore';
 
 export const fetchOutdoorDirections = async (
   request: DirectionsRequest,

--- a/mobile/src/services/shuttlePlanner.ts
+++ b/mobile/src/services/shuttlePlanner.ts
@@ -1,8 +1,7 @@
 import type { ShuttlePlan, ShuttlePlanRequest } from '../types/Shuttle';
 import { getShuttlePlanStrategy } from './directions/strategies/shuttlePlanStrategy';
-import { getNextShuttleDepartures, selectPickupDropoff } from './shuttlePlannerCore';
 
-export { getNextShuttleDepartures, selectPickupDropoff };
+export { getNextShuttleDepartures, selectPickupDropoff } from './shuttlePlannerCore';
 
 export const buildShuttlePlan = (request: ShuttlePlanRequest): ShuttlePlan => {
   const strategy = getShuttlePlanStrategy();

--- a/mobile/src/services/shuttlePlannerCore.ts
+++ b/mobile/src/services/shuttlePlannerCore.ts
@@ -51,7 +51,7 @@ const normalizeDepartureToken = (departure: string) => {
   const trimmedDeparture = departure.trim();
   let endIndex = trimmedDeparture.length;
 
-  while (endIndex > 0 && trimmedDeparture.charCodeAt(endIndex - 1) === STAR_CHAR_CODE) {
+  while (endIndex > 0 && trimmedDeparture.codePointAt(endIndex - 1) === STAR_CHAR_CODE) {
     endIndex -= 1;
   }
 

--- a/mobile/src/utils/buildingsRepository.ts
+++ b/mobile/src/utils/buildingsRepository.ts
@@ -30,6 +30,15 @@ type BuildingBoundaryProps = Record<string, unknown> & {
   id?: string | number;
 };
 
+type BuildingMetadata = {
+  campus: Campus;
+  name: string;
+  shortCode?: string;
+  address?: string;
+  images: string[];
+  services?: Record<string, string>;
+};
+
 const toStableId = (raw: unknown): string | null => {
   if (typeof raw === 'string' && raw.trim().length > 0) return raw.trim();
   if (typeof raw === 'number' && Number.isFinite(raw)) return String(raw);
@@ -91,6 +100,52 @@ const findContainingBuilding = (
   return undefined;
 };
 
+const toBuildingMetadataEntry = (
+  props: BuildingListProps,
+): { id: string; metadata: BuildingMetadata } | null => {
+  const id = toStableId(props.unique_id);
+  const campus = normalizeCampusCode(props.Campus);
+  if (!id || !campus) return null;
+
+  return {
+    id,
+    metadata: {
+      campus,
+      name: getBestBuildingName(props),
+      shortCode: typeof props.Building === 'string' ? props.Building : undefined,
+      address: typeof props.Address === 'string' ? props.Address : undefined,
+      images: props.Images ?? [],
+      services: props.Services,
+    },
+  };
+};
+
+const toBuildingShape = (
+  feature: GeoJsonFeatureCollection<BuildingBoundaryProps>['features'][number],
+  metaById: Map<string, BuildingMetadata>,
+): BuildingShape | null => {
+  const props = feature.properties ?? {};
+  const id = toStableId(props.unique_id);
+  if (!id) return null;
+
+  const meta = metaById.get(id);
+  if (!meta) return null; // Boundary exists without metadata, skip gracefully
+
+  const polygons = getFeaturePolygons(feature);
+  if (!polygons.length) return null; // Invalid geometry, skip gracefully
+
+  return {
+    id,
+    campus: meta.campus,
+    name: meta.name,
+    polygons,
+    shortCode: meta.shortCode,
+    address: meta.address,
+    images: meta.images,
+    services: meta.services,
+  };
+};
+
 /**
  * Parse and join datasets once, then reuse results (performance).
  */
@@ -98,31 +153,14 @@ let cachedAllBuildings: BuildingShape[] | null = null;
 
 const buildMetadataMap = (
   buildingList: GeoJsonFeatureCollection<BuildingListProps>,
-): Map<
-  string,
-  {
-    campus: Campus;
-    name: string;
-    shortCode?: string;
-    address?: string;
-    images: string[];
-    services?: Record<string, string>;
-  }
-> => {
-  const metaById = new Map();
+): Map<string, BuildingMetadata> => {
+  const metaById = new Map<string, BuildingMetadata>();
   for (const feature of buildingList.features) {
-    const props = feature.properties ?? {};
-    const id = toStableId(props.unique_id);
-    const campus = normalizeCampusCode(props.Campus);
-    if (!id || !campus) continue;
-    metaById.set(id, {
-      campus,
-      name: getBestBuildingName(props),
-      shortCode: typeof props.Building === 'string' ? props.Building : undefined,
-      address: typeof props.Address === 'string' ? props.Address : undefined,
-      images: props.Images ?? [],
-      services: props.Services,
-    });
+    const props = (feature.properties ?? {}) as BuildingListProps;
+    const entry = toBuildingMetadataEntry(props);
+    if (!entry) continue;
+
+    metaById.set(entry.id, entry.metadata);
   }
   return metaById;
 };
@@ -133,26 +171,10 @@ const joinBoundariesToMeta = (
 ): BuildingShape[] => {
   const results: BuildingShape[] = [];
   for (const feature of boundaries.features) {
-    const props = feature.properties ?? {};
-    const id = toStableId(props.unique_id);
-    if (!id) continue;
+    const building = toBuildingShape(feature, metaById);
+    if (!building) continue;
 
-    const meta = metaById.get(id);
-    if (!meta) continue; // Boundary exists without metadata, skip gracefully
-
-    const polygons = getFeaturePolygons(feature);
-    if (!polygons.length) continue; // Invalid geometry, skip gracefully
-
-    results.push({
-      id,
-      campus: meta.campus,
-      name: meta.name,
-      polygons,
-      shortCode: meta.shortCode,
-      address: meta.address,
-      images: meta.images,
-      services: meta.services,
-    });
+    results.push(building);
   }
   return results;
 };

--- a/mobile/src/utils/buildingsRepository.ts
+++ b/mobile/src/utils/buildingsRepository.ts
@@ -92,7 +92,7 @@ const findContainingBuilding = (
   campusBuildings: BuildingShape[],
 ): BuildingShape | undefined => {
   for (const building of campusBuildings) {
-    if (isPointInAnyPolygon(point as any, building.polygons)) {
+    if (isPointInAnyPolygon(point, building.polygons)) {
       return building;
     }
   }
@@ -124,8 +124,7 @@ const toBuildingShape = (
   feature: GeoJsonFeatureCollection<BuildingBoundaryProps>['features'][number],
   metaById: Map<string, BuildingMetadata>,
 ): BuildingShape | null => {
-  const props = feature.properties ?? {};
-  const id = toStableId(props.unique_id);
+  const id = toStableId(feature.properties?.unique_id);
   if (!id) return null;
 
   const meta = metaById.get(id);
@@ -156,7 +155,9 @@ const buildMetadataMap = (
 ): Map<string, BuildingMetadata> => {
   const metaById = new Map<string, BuildingMetadata>();
   for (const feature of buildingList.features) {
-    const props = (feature.properties ?? {}) as BuildingListProps;
+    const props = feature.properties;
+    if (!props) continue;
+
     const entry = toBuildingMetadataEntry(props);
     if (!entry) continue;
 

--- a/mobile/src/utils/buildingsRepository.ts
+++ b/mobile/src/utils/buildingsRepository.ts
@@ -62,6 +62,35 @@ const getBuildingDistance = (
   return centroid ? getDistance(point, centroid) : Number.MAX_VALUE;
 };
 
+const MAX_DISTANCE_METERS_FROM_CAMPUS = 2000;
+
+const getDistanceToCampusMeters = (
+  point: { latitude: number; longitude: number },
+  campus: Campus,
+) => {
+  const campusCenter = getCampusRegion(campus);
+  return getDistance(point, {
+    latitude: campusCenter.latitude,
+    longitude: campusCenter.longitude,
+  });
+};
+
+const isPointNearCampus = (point: { latitude: number; longitude: number }, campus: Campus) =>
+  getDistanceToCampusMeters(point, campus) <= MAX_DISTANCE_METERS_FROM_CAMPUS;
+
+const findContainingBuilding = (
+  point: { latitude: number; longitude: number },
+  campusBuildings: BuildingShape[],
+): BuildingShape | undefined => {
+  for (const building of campusBuildings) {
+    if (isPointInAnyPolygon(point as any, building.polygons)) {
+      return building;
+    }
+  }
+
+  return undefined;
+};
+
 /**
  * Parse and join datasets once, then reuse results (performance).
  */
@@ -169,29 +198,10 @@ export const findBuildingAt = (point: {
   latitude: number;
   longitude: number;
 }): BuildingShape | undefined => {
-  // Find which campus the user is closest to
   const closestCampus = findClosestCampus(point);
-  const campusCenter = getCampusRegion(closestCampus);
-
-  // Early exit if urser isnt atleast somewhat close to that campus
-  const MAX_DISTANCE_METERS = 2000;
-  const distanceToCampus = getDistance(point, {
-    latitude: campusCenter.latitude,
-    longitude: campusCenter.longitude,
-  });
-
-  if (distanceToCampus > MAX_DISTANCE_METERS) {
-    return undefined; // Too far away, skip building search
-  }
-
-  // User is near campus, proceed with building search
+  if (!isPointNearCampus(point, closestCampus)) return undefined;
   const campusBuildings = getCampusBuildingShapes(closestCampus);
-
-  for (const building of campusBuildings) {
-    if (isPointInAnyPolygon(point as any, building.polygons)) return building;
-  }
-
-  return undefined;
+  return findContainingBuilding(point, campusBuildings);
 };
 
 /**

--- a/mobile/src/utils/geoJson.ts
+++ b/mobile/src/utils/geoJson.ts
@@ -54,11 +54,9 @@ export const extractOuterRingsAsLatLngPolygons = (
     return [outerRing.map(toLatLng)];
   }
 
-  // MultiPolygon
-  const multi = geometry as GeoJsonMultiPolygon;
   const polygons: LatLng[][] = [];
 
-  for (const poly of multi.coordinates ?? []) {
+  for (const poly of geometry.coordinates ?? []) {
     const outerRing = poly?.[0];
     if (!outerRing || !isValidRing(outerRing)) continue;
     polygons.push(outerRing.map(toLatLng));
@@ -99,7 +97,7 @@ export const isPointInPolygon = (point: LatLng, polygon: LatLng[]): boolean => {
     const xj = polygon[j].longitude,
       yj = polygon[j].latitude;
 
-    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi + 0.0) + xi;
+    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi + 0) + xi;
     if (intersect) inside = !inside;
   }
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,4 +3,5 @@ sonar.organization=lamdadev
 sonar.sources=mobile
 sonar.tests=mobile/__test__
 sonar.javascript.lcov.reportPaths=mobile/coverage/lcov.info
+sonar.typescript.tsconfigPaths=mobile/tsconfig.json
 sonar.exclusions=mobile/App.tsx, mobile/index.tsx, mobile/__test__/**, mobile/babel.config.js, mobile/jest.setup.ts, mobile/jest.config.js, mobile/src/assets/geojson/index.ts, mobile/index.ts, mobile/eslint.config.js, mobile/__mocks__/**


### PR DESCRIPTION
## Summary
This PR implements TASK-3.2.4 by addressing SonarCloud findings across the mobile app codebase, with a focus on maintainability, readability, and consistency.

The branch is primarily refactor-oriented (code smells, complexity, style, and static-analysis cleanup), while preserving existing behavior and app UX.

It also includes a small set of related reliability fixes discovered during the cleanup work (notably route line style stability across travel-mode switches and Sonar pipeline quality improvements).

## Changes
- Refactored high/medium complexity hotspots in `mobile/src/components/BottomSheet.tsx`, `mobile/src/components/DirectionDetails.tsx`, `mobile/src/screens/MapScreen.tsx`, and `mobile/src/utils/buildingsRepository.ts`.
- Removed Sonar-flagged `void` callback usage in `mobile/src/App.tsx` by introducing a dedicated async-safe calendar opener callback.
- Fixed route polyline rendering consistency in `mobile/src/screens/MapScreen.tsx` so walking segments are dashed and non-walking segments are solid, including mode-switch stability.
- Reworked `mobile/src/components/BuildingDetails.tsx` to remove index-based keys and improve list rendering stability.
- Moved inline component definitions and simplified nested conditionals in:
  - `mobile/src/components/CalendarSelectionCard.tsx`
  - `mobile/src/components/ShuttleScheduleDetails.tsx`
  - `mobile/src/components/UpcomingClassesSlider.tsx`
- Addressed Sonar string/API style issues in `mobile/src/services/directions/googleDirectionsCore.ts` (`replaceAll`, `endsWith`, optional chaining simplifications).
- Addressed `codePointAt`/Unicode handling in `mobile/src/services/shuttlePlannerCore.ts`.
- Applied re-export consistency in:
  - `mobile/src/services/googleDirections.ts`
  - `mobile/src/services/shuttlePlanner.ts`
- Fixed undefined comparison style in `mobile/src/services/googleCalendarAuth.ts`.
- Cleaned utility type/assertion issues and numeric style findings in:
  - `mobile/src/utils/buildingsRepository.ts`
  - `mobile/src/utils/geoJson.ts`
- Updated ESLint ignores to exclude native generated folders (`ios/**`, `android/**`) in `mobile/eslint.config.js` to prevent third-party/native noise.
- Refactored `mobile/app.config.js` to remove nested ternary/object-spread Sonar smells while keeping config behavior intact.
- Improved Sonar CI setup:
  - added Node setup and `npm ci` before Sonar analysis in `.github/workflows/sonarcloud.yml`
  - added `sonar.typescript.tsconfigPaths=mobile/tsconfig.json` in `sonar-project.properties`

## Tests Added/Updated
- Updated `mobile/__test__/MapScreen.test.tsx` for route-line behavior and rendering expectations:
  - dashed walking vs solid non-walking segments
  - line-cap expectations
  - mode-switch style stability
  - removal of platform-specific `strokeColors` expectation now that route rendering is normalized

## How to Test

### Running the application
1. `cd mobile`
2. `npm install`
3. Ensure `.env` includes required keys (at minimum Google Maps key and calendar client IDs used by your env).
4. Run app (`npm start` or platform run command).
5. Verify key flows still work:
   - building selection/search + bottom sheet flows
   - walking/driving/transit/shuttle direction flows
   - walking route appears dashed, driving route appears solid
   - switching travel modes keeps route style correct
   - Google Calendar connect/open flows still function
<img width="2638" height="1548" alt="CleanShot 2026-03-05 at 21 31 04@2x" src="https://github.com/user-attachments/assets/d4b0db2a-8a89-46cb-9250-da0a02d80c67" />

### Running the updated checks
1. `npm run lint`
2. `npm test -- --watchman=false`
3. (Optional) `npm run test:coverage -- --watchman=false`

## Notes
- Scope is Sonar-driven refactor and cleanup across multiple files; no intentional product-scope expansion.
- Changes are behavior-preserving unless explicitly fixing incorrect behavior (route style consistency).
- Sonar pipeline/config updates are included so analysis quality matches local source/build context.
- Native generated code (`ios/Pods`, `android`) is excluded from lint noise.

## Checklist
- [ ] Builds/runs locally (manual app verification)
- [x] Implements TASK-3.2.4 Sonar-focused refactor scope
- [x] Addresses maintainability/readability/code-smell findings across impacted files
- [x] Preserves existing app behavior and interaction flows
- [x] Updated/adjusted tests where behavior/assertions changed
- [x] Test checks pass (`npm test -- --watchman=false`)
- [ ] Coverage checks pass (`npm run test:coverage`)
- [x] Lint checks pass (`npm run lint`)
- [ ] Screenshots/GIF included (if required by reviewers)
- [x] Ready for review

