### PR TITLE
CHORE: GH-236-sonar-code-issues-fix

### DIFF
--- a/mobile/__test__/App.test.tsx
+++ b/mobile/__test__/App.test.tsx
@@ -251,4 +251,21 @@ describe('App', () => {
       expect(mockOpenCalendarEventsSlider).toHaveBeenCalledWith();
     });
   });
+
+  test('calendar shortcut logs warning when calendar state loading fails', async () => {
+    const error = new Error('calendar auth read failed');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockGetStoredGoogleCalendarSessionState.mockRejectedValueOnce(error);
+
+    const { getByTestId } = render(<App />);
+
+    fireEvent.press(getByTestId('open-calendar-shortcut'));
+
+    await waitFor(() => {
+      expect(mockBottomSheetOpen).toHaveBeenCalledWith(1);
+      expect(warnSpy).toHaveBeenCalledWith('Failed to open calendar from map action', error);
+    });
+
+    warnSpy.mockRestore();
+  });
 });

--- a/mobile/__test__/app.config.test.ts
+++ b/mobile/__test__/app.config.test.ts
@@ -103,4 +103,58 @@ describe('app.config', () => {
     warnSpy.mockRestore();
     jest.dontMock('../app.json');
   });
+
+  test('handles single string scheme and skips empty google client-id prefixes', () => {
+    delete process.env.EXPO_PUBLIC_GOOGLE_CALENDAR_ANDROID_CLIENT_ID;
+    process.env.EXPO_PUBLIC_GOOGLE_CALENDAR_IOS_CLIENT_ID = '.apps.googleusercontent.com';
+
+    jest.resetModules();
+    jest.doMock('../app.json', () => ({
+      expo: {
+        name: 'mobile',
+        slug: 'mobile',
+        scheme: 'gittocampus-single',
+        ios: {
+          infoPlist: {
+            NSAppTransportSecurity: {
+              NSExceptionDomains: {
+                'legacy.example.com': {
+                  NSIncludesSubdomains: false,
+                },
+              },
+            },
+          },
+        },
+        android: {
+          package: 'com.anonymous.mobile',
+          config: {
+            googleMaps: {},
+          },
+        },
+      },
+    }));
+
+    const config = require('../app.config.js');
+
+    expect(config.scheme).toEqual(
+      expect.arrayContaining(['gittocampus-single', 'com.anonymous.mobile']),
+    );
+    expect(
+      config.scheme.some(
+        (scheme: string) =>
+          scheme.startsWith('com.googleusercontent.apps.') &&
+          scheme !== 'com.googleusercontent.apps.',
+      ),
+    ).toBe(false);
+    expect(config.ios.infoPlist.NSAppTransportSecurity.NSExceptionDomains).toMatchObject({
+      'legacy.example.com': {
+        NSIncludesSubdomains: false,
+      },
+      'iili.io': {
+        NSIncludesSubdomains: true,
+      },
+    });
+
+    jest.dontMock('../app.json');
+  });
 });

--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -41,7 +41,7 @@ const appTransportSecurity = {
   NSAllowsArbitraryLoads: false,
   NSAllowsLocalNetworking: true,
   NSExceptionDomains: {
-    ...(expo.ios?.infoPlist?.NSAppTransportSecurity?.NSExceptionDomains ?? {}),
+    ...expo.ios?.infoPlist?.NSAppTransportSecurity?.NSExceptionDomains,
     ...Object.fromEntries(
       BUILDING_IMAGE_HOSTS.map((host) => [host, { ...imageHostTransportException }]),
     ),

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -116,7 +116,7 @@ const App = () => {
           bottomSheetAnimatedPosition={bottomSheetAnimatedPosition}
         />
 
-        {!sheetOpen ? <AppSearchBar openSearch={openSearchBuilding} /> : null}
+        {sheetOpen ? null : <AppSearchBar openSearch={openSearchBuilding} />}
 
         <BottomSlider
           userLocation={userLocation}

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -991,19 +991,19 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
 
       const canComputeShuttlePlan =
         shouldComputeShuttlePlan && startCampus !== null && destinationCampus !== null;
-      if (!canComputeShuttlePlan) {
-        setShuttlePlan(null);
+      if (canComputeShuttlePlan) {
+        setShuttlePlan(
+          buildShuttlePlan({
+            startCampus,
+            destinationCampus,
+            startCoords: startCoords ?? null,
+            now: getShuttlePlanningDate(new Date()),
+          }),
+        );
         return;
       }
 
-      setShuttlePlan(
-        buildShuttlePlan({
-          startCampus,
-          destinationCampus,
-          startCoords: startCoords ?? null,
-          now: getShuttlePlanningDate(new Date()),
-        }),
-      );
+      setShuttlePlan(null);
     }, [activeView, destinationCampus, startCampus, startCoords, travelMode]);
 
     const showNavigationSummary = useCallback(() => {

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -52,8 +52,12 @@ const WALKING_DASH_PATTERN = [12, 8];
 const ROUTE_POLYLINE_STROKE_PROPS = { strokeColor: ROUTE_LINE_COLOR } as const;
 const POLYGON_PRESS_GUARD_RESET_DELAY_MS = 0;
 
-type PolygonPressGuardTimeoutRef = React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
-type IgnoreMapPressRef = React.MutableRefObject<boolean>;
+type PolygonPressGuardTimeoutRef = {
+  current: ReturnType<typeof setTimeout> | null;
+};
+type IgnoreMapPressRef = {
+  current: boolean;
+};
 
 type RoutePolylineSegment = {
   key: string;

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -316,6 +316,34 @@ const getPolygonCenter = (coordinates: { latitude: number; longitude: number }[]
   }
 };
 
+const getPolygonRenderColors = (
+  theme: (typeof POLYGON_THEME)[Campus],
+  isSelected: boolean,
+  isCurrent: boolean,
+) => {
+  if (isSelected) {
+    return {
+      strokeColor: theme.selectedStroke,
+      fillColor: theme.selectedFill,
+      strokeWidth: theme.selectedStrokeWidth,
+    };
+  }
+
+  if (isCurrent) {
+    return {
+      strokeColor: theme.currentStroke,
+      fillColor: theme.currentFill,
+      strokeWidth: theme.currentStrokeWidth,
+    };
+  }
+
+  return {
+    strokeColor: theme.stroke,
+    fillColor: theme.fill,
+    strokeWidth: theme.strokeWidth,
+  };
+};
+
 const renderPolygonItem = (
   item: PolygonRenderItem,
   selectedBuildingId: string | null,
@@ -326,18 +354,11 @@ const renderPolygonItem = (
   const isSelected = item.buildingId === selectedBuildingId;
   const isCurrent = item.buildingId === currentBuildingId;
   const center = getPolygonCenter(item.coordinates);
-
-  const strokeColor = isSelected
-    ? theme.selectedStroke
-    : isCurrent
-      ? theme.currentStroke
-      : theme.stroke;
-  const fillColor = isSelected ? theme.selectedFill : isCurrent ? theme.currentFill : theme.fill;
-  const strokeWidth = isSelected
-    ? theme.selectedStrokeWidth
-    : isCurrent
-      ? theme.currentStrokeWidth
-      : theme.strokeWidth;
+  const { strokeColor, fillColor, strokeWidth } = getPolygonRenderColors(
+    theme,
+    isSelected,
+    isCurrent,
+  );
 
   return (
     <Fragment key={item.key}>
@@ -474,9 +495,8 @@ function MapScreen({
   const handleUserPositionUpdate = useCallback((coords: UserCoords) => {
     setUserCoords((previousCoords) => {
       if (
-        previousCoords &&
-        previousCoords.latitude === coords.latitude &&
-        previousCoords.longitude === coords.longitude
+        previousCoords?.latitude === coords.latitude &&
+        previousCoords?.longitude === coords.longitude
       ) {
         return previousCoords;
       }

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -52,6 +52,9 @@ const WALKING_DASH_PATTERN = [12, 8];
 const ROUTE_POLYLINE_STROKE_PROPS = { strokeColor: ROUTE_LINE_COLOR } as const;
 const POLYGON_PRESS_GUARD_RESET_DELAY_MS = 0;
 
+type PolygonPressGuardTimeoutRef = React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
+type IgnoreMapPressRef = React.MutableRefObject<boolean>;
+
 type RoutePolylineSegment = {
   key: string;
   coordinates: { latitude: number; longitude: number }[];
@@ -389,6 +392,65 @@ const initLocationTracking = async (
   return watchUserLocation(onPositionUpdate);
 };
 
+type LocationTrackingLifecycle = {
+  isActive: boolean;
+  subscription: Location.LocationSubscription | null;
+};
+
+const startLocationTrackingForLifecycle = async (
+  onPositionUpdate: (coords: UserCoords) => void,
+  lifecycle: LocationTrackingLifecycle,
+) => {
+  const nextSubscription = await initLocationTracking(onPositionUpdate);
+  if (!lifecycle.isActive) {
+    nextSubscription?.remove();
+    return;
+  }
+
+  lifecycle.subscription = nextSubscription;
+};
+
+const clearPolygonPressGuardTimeout = (
+  polygonPressGuardTimeoutRef: PolygonPressGuardTimeoutRef,
+) => {
+  if (polygonPressGuardTimeoutRef.current === null) return;
+  clearTimeout(polygonPressGuardTimeoutRef.current);
+  polygonPressGuardTimeoutRef.current = null;
+};
+
+const resetPolygonPressGuard = (
+  shouldIgnoreNextMapPressRef: IgnoreMapPressRef,
+  polygonPressGuardTimeoutRef: PolygonPressGuardTimeoutRef,
+) => {
+  shouldIgnoreNextMapPressRef.current = false;
+  polygonPressGuardTimeoutRef.current = null;
+};
+
+const armPolygonPressGuard = (
+  shouldIgnoreNextMapPressRef: IgnoreMapPressRef,
+  polygonPressGuardTimeoutRef: PolygonPressGuardTimeoutRef,
+) => {
+  shouldIgnoreNextMapPressRef.current = true;
+  clearPolygonPressGuardTimeout(polygonPressGuardTimeoutRef);
+  polygonPressGuardTimeoutRef.current = setTimeout(
+    resetPolygonPressGuard,
+    POLYGON_PRESS_GUARD_RESET_DELAY_MS,
+    shouldIgnoreNextMapPressRef,
+    polygonPressGuardTimeoutRef,
+  );
+};
+
+const consumePolygonPressGuard = (
+  shouldIgnoreNextMapPressRef: IgnoreMapPressRef,
+  polygonPressGuardTimeoutRef: PolygonPressGuardTimeoutRef,
+): boolean => {
+  if (!shouldIgnoreNextMapPressRef.current) return false;
+
+  shouldIgnoreNextMapPressRef.current = false;
+  clearPolygonPressGuardTimeout(polygonPressGuardTimeoutRef);
+  return true;
+};
+
 function MapScreen({
   passSelectedBuilding,
   passUserLocation,
@@ -434,27 +496,16 @@ function MapScreen({
   }, [currentBuildingId, passCurrentBuilding]);
 
   useEffect(() => {
-    let subscription: Location.LocationSubscription | null = null;
-    let isActive = true;
-
-    const startTracking = async () => {
-      const nextSubscription = await initLocationTracking(handleUserPositionUpdate);
-      if (!isActive) {
-        nextSubscription?.remove();
-        return;
-      }
-      subscription = nextSubscription;
+    const lifecycle: LocationTrackingLifecycle = {
+      isActive: true,
+      subscription: null,
     };
-
-    void startTracking();
+    void startLocationTrackingForLifecycle(handleUserPositionUpdate, lifecycle);
 
     return () => {
-      isActive = false;
-      subscription?.remove();
-      if (polygonPressGuardTimeoutRef.current !== null) {
-        clearTimeout(polygonPressGuardTimeoutRef.current);
-        polygonPressGuardTimeoutRef.current = null;
-      }
+      lifecycle.isActive = false;
+      lifecycle.subscription?.remove();
+      clearPolygonPressGuardTimeout(polygonPressGuardTimeoutRef);
     };
   }, [handleUserPositionUpdate]);
 
@@ -502,14 +553,7 @@ function MapScreen({
 
   const handlePolygonPress = useCallback(
     (item: PolygonRenderItem) => {
-      shouldIgnoreNextMapPressRef.current = true;
-      if (polygonPressGuardTimeoutRef.current !== null) {
-        clearTimeout(polygonPressGuardTimeoutRef.current);
-      }
-      polygonPressGuardTimeoutRef.current = setTimeout(() => {
-        shouldIgnoreNextMapPressRef.current = false;
-        polygonPressGuardTimeoutRef.current = null;
-      }, POLYGON_PRESS_GUARD_RESET_DELAY_MS);
+      armPolygonPressGuard(shouldIgnoreNextMapPressRef, polygonPressGuardTimeoutRef);
 
       setSelectedBuildingId(item.buildingId);
       setSelectedCampus(item.campus);
@@ -541,14 +585,7 @@ function MapScreen({
   }, [userCoords]);
 
   const handleMapPress = useCallback(() => {
-    if (shouldIgnoreNextMapPressRef.current) {
-      shouldIgnoreNextMapPressRef.current = false;
-      if (polygonPressGuardTimeoutRef.current !== null) {
-        clearTimeout(polygonPressGuardTimeoutRef.current);
-        polygonPressGuardTimeoutRef.current = null;
-      }
-      return;
-    }
+    if (consumePolygonPressGuard(shouldIgnoreNextMapPressRef, polygonPressGuardTimeoutRef)) return;
 
     setSelectedBuildingId(null);
     passSelectedBuilding(null);

--- a/mobile/src/services/googleCalendarAuth.ts
+++ b/mobile/src/services/googleCalendarAuth.ts
@@ -587,6 +587,122 @@ export const fetchGoogleCalendarEventsAsync = async (
   }
 };
 
+type SuccessfulPromptResult = Extract<AuthSession.AuthSessionResult, { type: 'success' }>;
+type PromptErrorResult = Extract<AuthSession.AuthSessionResult, { type: 'error' }>;
+
+type PromptResolution =
+  | { shouldContinue: true; promptResult: SuccessfulPromptResult }
+  | { shouldContinue: false; result: GoogleCalendarConnectResult };
+
+type TokenResponseResolution =
+  | { ok: true; tokenResponse: AuthSession.TokenResponse }
+  | { ok: false; result: GoogleCalendarConnectResult };
+
+const resolvePromptError = (promptResult: PromptErrorResult): GoogleCalendarConnectResult => {
+  const oauthErrorCode = (promptResult.params.error ?? '').toLowerCase();
+  if (oauthErrorCode === 'access_denied') {
+    return { type: 'denied' };
+  }
+
+  if (oauthErrorCode === 'deleted_client' || oauthErrorCode === 'invalid_client') {
+    return {
+      type: 'error',
+      message:
+        `Google OAuth client is invalid or deleted. Update ${getPlatformClientIdEnvName()} ` +
+        'in mobile/.env and rebuild the dev client.',
+    };
+  }
+
+  const oauthErrorDescription = (promptResult.params.error_description ?? '').trim();
+  return {
+    type: 'error',
+    message: oauthErrorDescription || mapPromptErrorToMessage(promptResult.error),
+  };
+};
+
+const resolvePromptResult = (promptResult: AuthSession.AuthSessionResult): PromptResolution => {
+  if (promptResult.type === 'success') {
+    return {
+      shouldContinue: true,
+      promptResult,
+    };
+  }
+
+  if (promptResult.type === 'cancel' || promptResult.type === 'dismiss') {
+    return {
+      shouldContinue: false,
+      result: { type: 'cancel' },
+    };
+  }
+
+  if (promptResult.type === 'locked') {
+    return {
+      shouldContinue: false,
+      result: {
+        type: 'error',
+        message: 'Google sign-in is already active. Please wait and try again.',
+      },
+    };
+  }
+
+  if (promptResult.type === 'error') {
+    return {
+      shouldContinue: false,
+      result: resolvePromptError(promptResult),
+    };
+  }
+
+  return {
+    shouldContinue: false,
+    result: {
+      type: 'error',
+      message: 'Google sign-in did not complete. Please try again.',
+    },
+  };
+};
+
+const resolveTokenResponse = async ({
+  promptResult,
+  request,
+  clientId,
+  redirectUri,
+}: {
+  promptResult: SuccessfulPromptResult;
+  request: Awaited<ReturnType<typeof AuthSession.loadAsync>>;
+  clientId: string;
+  redirectUri: string;
+}): Promise<TokenResponseResolution> => {
+  if (promptResult.authentication) {
+    return { ok: true, tokenResponse: promptResult.authentication };
+  }
+
+  const authCode = promptResult.params.code;
+  if (!isNonEmptyString(authCode)) {
+    return {
+      ok: false,
+      result: {
+        type: 'error',
+        message: 'Google authentication completed without an authorization code.',
+      },
+    };
+  }
+
+  const tokenResponse = await AuthSession.exchangeCodeAsync(
+    {
+      clientId,
+      code: authCode,
+      redirectUri,
+      extraParams: request.codeVerifier
+        ? {
+            code_verifier: request.codeVerifier,
+          }
+        : undefined,
+    },
+    GOOGLE_CALENDAR_DISCOVERY,
+  );
+  return { ok: true, tokenResponse };
+};
+
 export const connectGoogleCalendarAsync = async (): Promise<GoogleCalendarConnectResult> => {
   const clientId = getConfiguredClientId();
   if (!clientId) {
@@ -629,75 +745,22 @@ export const connectGoogleCalendarAsync = async (): Promise<GoogleCalendarConnec
     );
 
     const promptResult = await request.promptAsync(GOOGLE_CALENDAR_DISCOVERY);
-
-    if (promptResult.type === 'cancel' || promptResult.type === 'dismiss') {
-      return { type: 'cancel' };
+    const promptResolution = resolvePromptResult(promptResult);
+    if (!promptResolution.shouldContinue) {
+      return promptResolution.result;
     }
 
-    if (promptResult.type === 'locked') {
-      return {
-        type: 'error',
-        message: 'Google sign-in is already active. Please wait and try again.',
-      };
+    const tokenResolution = await resolveTokenResponse({
+      promptResult: promptResolution.promptResult,
+      request,
+      clientId,
+      redirectUri,
+    });
+    if (!tokenResolution.ok) {
+      return tokenResolution.result;
     }
 
-    if (promptResult.type === 'error') {
-      const oauthErrorCode = (promptResult.params.error ?? '').toLowerCase();
-
-      if (oauthErrorCode === 'access_denied') {
-        return { type: 'denied' };
-      }
-
-      if (oauthErrorCode === 'deleted_client' || oauthErrorCode === 'invalid_client') {
-        return {
-          type: 'error',
-          message:
-            `Google OAuth client is invalid or deleted. Update ${getPlatformClientIdEnvName()} ` +
-            'in mobile/.env and rebuild the dev client.',
-        };
-      }
-
-      const oauthErrorDescription = (promptResult.params.error_description ?? '').trim();
-      return {
-        type: 'error',
-        message: oauthErrorDescription || mapPromptErrorToMessage(promptResult.error),
-      };
-    }
-
-    if (promptResult.type !== 'success') {
-      return {
-        type: 'error',
-        message: 'Google sign-in did not complete. Please try again.',
-      };
-    }
-
-    let tokenResponse = promptResult.authentication;
-
-    if (!tokenResponse) {
-      const authCode = promptResult.params.code;
-      if (!isNonEmptyString(authCode)) {
-        return {
-          type: 'error',
-          message: 'Google authentication completed without an authorization code.',
-        };
-      }
-
-      tokenResponse = await AuthSession.exchangeCodeAsync(
-        {
-          clientId,
-          code: authCode,
-          redirectUri,
-          extraParams: request.codeVerifier
-            ? {
-                code_verifier: request.codeVerifier,
-              }
-            : undefined,
-        },
-        GOOGLE_CALENDAR_DISCOVERY,
-      );
-    }
-
-    const session = toSession(tokenResponse);
+    const session = toSession(tokenResolution.tokenResponse);
     await saveGoogleCalendarSession(session);
 
     return {

--- a/mobile/src/services/googleCalendarAuth.ts
+++ b/mobile/src/services/googleCalendarAuth.ts
@@ -148,19 +148,21 @@ const getGoogleClientRedirectScheme = (clientId: string): string | null => {
   return `com.googleusercontent.apps.${clientIdPrefix}`;
 };
 
-const getRedirectScheme = (): string =>
-  Platform.OS === 'ios'
-    ? (
-        getGoogleClientRedirectScheme(
-          process.env.EXPO_PUBLIC_GOOGLE_CALENDAR_IOS_CLIENT_ID ?? '',
-        ) ??
-        Application.applicationId ??
-        IOS_BUNDLE_ID_FALLBACK
-      ).trim()
-    : (
-        Application.applicationId ??
-        (Platform.OS === 'android' ? ANDROID_PACKAGE_FALLBACK : APP_SCHEME)
-      ).trim();
+const getRedirectScheme = (): string => {
+  if (Platform.OS === 'ios') {
+    return (
+      getGoogleClientRedirectScheme(process.env.EXPO_PUBLIC_GOOGLE_CALENDAR_IOS_CLIENT_ID ?? '') ??
+      Application.applicationId ??
+      IOS_BUNDLE_ID_FALLBACK
+    ).trim();
+  }
+
+  if (Platform.OS === 'android') {
+    return (Application.applicationId ?? ANDROID_PACKAGE_FALLBACK).trim();
+  }
+
+  return (Application.applicationId ?? APP_SCHEME).trim();
+};
 
 const createRedirectUri = () =>
   AuthSession.makeRedirectUri({
@@ -248,12 +250,17 @@ const buildGoogleCalendarEventsEndpoint = ({
   return `${GOOGLE_CALENDAR_EVENTS_ENDPOINT}/${encodeURIComponent(calendarId)}/events?${queryParams.join('&')}`;
 };
 
-const getPlatformClientIdEnvName = (): string =>
-  Platform.OS === 'android'
-    ? 'EXPO_PUBLIC_GOOGLE_CALENDAR_ANDROID_CLIENT_ID'
-    : Platform.OS === 'ios'
-      ? 'EXPO_PUBLIC_GOOGLE_CALENDAR_IOS_CLIENT_ID'
-      : 'EXPO_PUBLIC_GOOGLE_CALENDAR_WEB_CLIENT_ID';
+const getPlatformClientIdEnvName = (): string => {
+  if (Platform.OS === 'android') {
+    return 'EXPO_PUBLIC_GOOGLE_CALENDAR_ANDROID_CLIENT_ID';
+  }
+
+  if (Platform.OS === 'ios') {
+    return 'EXPO_PUBLIC_GOOGLE_CALENDAR_IOS_CLIENT_ID';
+  }
+
+  return 'EXPO_PUBLIC_GOOGLE_CALENDAR_WEB_CLIENT_ID';
+};
 
 export const saveGoogleCalendarSession = async (session: GoogleCalendarSession): Promise<void> => {
   await SecureStore.setItemAsync(

--- a/mobile/src/utils/buildingsRepository.ts
+++ b/mobile/src/utils/buildingsRepository.ts
@@ -45,14 +45,19 @@ const toStableId = (raw: unknown): string | null => {
   return null;
 };
 
-const getBestBuildingName = (props: BuildingListProps): string => {
-  const longName = props['Building Long Name'];
-  if (typeof longName === 'string' && longName.trim()) return longName.trim();
-  if (typeof props.BuildingName === 'string' && props.BuildingName.trim())
-    return props.BuildingName.trim();
-  if (typeof props.Building === 'string' && props.Building.trim()) return props.Building.trim();
+const toTrimmedNonEmptyString = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
 
-  return 'Unknown Building';
+const getBestBuildingName = (props: BuildingListProps): string => {
+  return (
+    toTrimmedNonEmptyString(props['Building Long Name']) ??
+    toTrimmedNonEmptyString(props.BuildingName) ??
+    toTrimmedNonEmptyString(props.Building) ??
+    'Unknown Building'
+  );
 };
 
 const getPolygonCentroid = (polygon: { latitude: number; longitude: number }[] | undefined) => {

--- a/mobile/src/utils/buildingsRepository.ts
+++ b/mobile/src/utils/buildingsRepository.ts
@@ -2,7 +2,7 @@ import { GEOJSON_ASSETS } from '../assets/geojson';
 import type { GeoJsonFeatureCollection } from '../types/GeoJson';
 import type { Campus } from '../types/Campus';
 import type { BuildingShape } from '../types/BuildingShape';
-import { getFeaturePolygons, normalizeCampusCode, isPointInAnyPolygon } from '../utils/geoJson';
+import { getFeaturePolygons, normalizeCampusCode, isPointInAnyPolygon } from './geoJson';
 import { getDistance } from 'geolib';
 import { getCampusRegion } from '../constants/campuses';
 
@@ -176,14 +176,12 @@ const buildBuildingIndexes = (allBuildings: BuildingShape[]) => {
 };
 
 const ensureBuildingsCache = () => {
-  if (!cachedAllBuildings) {
-    cachedAllBuildings = buildAllBuildingsCache();
-  }
+  cachedAllBuildings ??= buildAllBuildingsCache();
 
   if (!cachedBuildingsByCampus || !cachedBuildingById) {
     const indexes = buildBuildingIndexes(cachedAllBuildings);
-    cachedBuildingsByCampus = indexes.buildingsByCampus;
-    cachedBuildingById = indexes.buildingById;
+    cachedBuildingsByCampus ??= indexes.buildingsByCampus;
+    cachedBuildingById ??= indexes.buildingById;
   }
 
   return cachedAllBuildings;
@@ -220,10 +218,9 @@ const joinBoundariesToMeta = (
 };
 
 const buildAllBuildingsCache = (): BuildingShape[] => {
-  const buildingList =
-    GEOJSON_ASSETS.buildingList as unknown as GeoJsonFeatureCollection<BuildingListProps>;
+  const buildingList = GEOJSON_ASSETS.buildingList as GeoJsonFeatureCollection<BuildingListProps>;
   const boundaries =
-    GEOJSON_ASSETS.buildingBoundaries as unknown as GeoJsonFeatureCollection<BuildingBoundaryProps>;
+    GEOJSON_ASSETS.buildingBoundaries as GeoJsonFeatureCollection<BuildingBoundaryProps>;
   return joinBoundariesToMeta(boundaries, buildMetadataMap(buildingList));
 };
 

--- a/mobile/src/utils/geoJson.ts
+++ b/mobile/src/utils/geoJson.ts
@@ -97,7 +97,10 @@ export const isPointInPolygon = (point: LatLng, polygon: LatLng[]): boolean => {
     const xj = polygon[j].longitude,
       yj = polygon[j].latitude;
 
-    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi + 0) + xi;
+    const denominator = yj - yi;
+    if (denominator === 0) continue;
+
+    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / denominator + xi;
     if (intersect) inside = !inside;
   }
 


### PR DESCRIPTION
## Summary
This PR implements TASK-3.2.4 by addressing SonarCloud findings across the mobile app codebase, with a focus on maintainability, readability, and consistency.

The branch is primarily refactor-oriented (code smells, complexity, style, and static-analysis cleanup) while preserving existing behavior and app UX.

It also includes a small set of reliability fixes discovered during cleanup work, notably route line style stability across travel-mode switches and Sonar pipeline quality improvements.

## Changes
- Refactored high/medium complexity hotspots in `mobile/src/components/BottomSheet.tsx`, `mobile/src/components/DirectionDetails.tsx`, `mobile/src/screens/MapScreen.tsx`, and `mobile/src/utils/buildingsRepository.ts`.
- Removed Sonar-flagged `void` callback usage in `mobile/src/App.tsx` by introducing a dedicated async-safe calendar opener callback.
- Fixed route polyline rendering consistency in `mobile/src/screens/MapScreen.tsx` so walking segments are dashed and non-walking segments are solid, including mode-switch stability.
- Reworked `mobile/src/components/BuildingDetails.tsx` to remove index-based keys and improve list rendering stability.
- Moved inline component definitions and simplified nested conditionals in `mobile/src/components/CalendarSelectionCard.tsx`.
- Moved inline component definitions and simplified nested conditionals in `mobile/src/components/ShuttleScheduleDetails.tsx`.
- Moved inline component definitions and simplified nested conditionals in `mobile/src/components/UpcomingClassesSlider.tsx`.
- Addressed Sonar string/API style issues in `mobile/src/services/directions/googleDirectionsCore.ts` (`replaceAll`, `endsWith`, optional chaining simplifications).
- Addressed `codePointAt`/Unicode handling in `mobile/src/services/shuttlePlannerCore.ts`.
- Applied re-export consistency in `mobile/src/services/googleDirections.ts`.
- Applied re-export consistency in `mobile/src/services/shuttlePlanner.ts`.
- Fixed undefined comparison style in `mobile/src/services/googleCalendarAuth.ts`.
- Cleaned utility type/assertion issues and numeric style findings in `mobile/src/utils/buildingsRepository.ts` and `mobile/src/utils/geoJson.ts`.
- Updated ESLint ignores to exclude native generated folders (`ios/**`, `android/**`) in `mobile/eslint.config.js` to prevent third-party/native noise.
- Refactored `mobile/app.config.js` to remove nested ternary/object-spread Sonar smells while keeping config behavior intact.
- Improved Sonar CI setup by adding Node setup and `npm ci` before Sonar analysis in `.github/workflows/sonarcloud.yml`.
- Added `sonar.typescript.tsconfigPaths=mobile/tsconfig.json` in `sonar-project.properties`.

## Tests Added/Updated
- Updated `mobile/__test__/MapScreen.test.tsx` for route-line behavior and rendering expectations:
- dashed walking vs solid non-walking segments
- line-cap expectations
- mode-switch style stability
- removal of platform-specific `strokeColors` expectation now that route rendering is normalized

## How to Test

### Running the application
1. `cd mobile`
2. `npm install`
3. Ensure `.env` includes required keys (at minimum Google Maps key and calendar client IDs used by your env).
4. Run app (`npm start` or platform run command).
5. Verify key flows still work:
- building selection/search + bottom sheet flows
- walking/driving/transit/shuttle direction flows
- walking route appears dashed, driving route appears solid
- switching travel modes keeps route style correct
- Google Calendar connect/open flows still function


### Running the updated checks
1. `npm run lint`
2. `npm test -- --watchman=false`
3. (Optional) `npm run test:coverage -- --watchman=false`

## Notes
- Scope is Sonar-driven refactor and cleanup across multiple files; no intentional product-scope expansion.
- Changes are behavior-preserving unless explicitly fixing incorrect behavior (route style consistency).
- Sonar pipeline/config updates are included so analysis quality matches local source/build context.
- Native generated code (`ios/Pods`, `android`) is excluded from lint noise.

## Checklist
- [ ] Builds/runs locally (manual app verification)
- [x] Implements TASK-3.2.4 Sonar-focused refactor scope
- [x] Addresses maintainability/readability/code-smell findings across impacted files
- [x] Preserves existing app behavior and interaction flows
- [x] Updated/adjusted tests where behavior/assertions changed
- [x] Test checks pass (`npm test -- --watchman=false`)
- [ ] Coverage checks pass (`npm run test:coverage`)
- [x] Lint checks pass (`npm run lint`)
- [ ] Screenshots/GIF included (if required by reviewers)
- [x] Ready for review
