### PR TITLE
Refac/task 4.7.1 fix campus building labels

### DIFF
--- a/mobile/__test__/MapScreen.test.tsx
+++ b/mobile/__test__/MapScreen.test.tsx
@@ -1108,7 +1108,7 @@ describe('MapScreen', () => {
   });
 
   test('renders all polygons with markers and labels', async () => {
-    const { getAllByTestId } = render(
+    const { getAllByTestId, getByTestId } = render(
       <MapScreen
         passSelectedBuilding={mockPassSelectedBuilding}
         passUserLocation={mockPassUserLocation}
@@ -1119,6 +1119,17 @@ describe('MapScreen', () => {
       />,
     );
 
+    const map = getByTestId('campus-map');
+
+    act(() => {
+      map.props.onRegionChangeComplete({
+        latitude: 45,
+        longitude: -73,
+        latitudeDelta: 0.001,
+        longitudeDelta: 0.001,
+      });
+    });
+
     await waitFor(() => {
       const markers = getAllByTestId('map-label');
       expect(markers.length).toBe(mockBuildings.reduce((sum, b) => sum + b.polygons.length, 0));
@@ -1126,7 +1137,6 @@ describe('MapScreen', () => {
 
     expect(getAllByTestId('map-label')).toBeTruthy();
   });
-
   test('pressing a polygon selects it and applies styling', async () => {
     const { UNSAFE_getAllByType } = render(
       <MapScreen

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -425,6 +425,7 @@ const renderPolygonItem = (
     isCurrent,
   );
 
+  const showBuildingLabel = zoomLevel < SHOW_LABEL_ZOOM_THRESHOLD;
   return (
     <Fragment key={item.key}>
       <Polygon
@@ -436,7 +437,7 @@ const renderPolygonItem = (
         onPress={() => onPolygonPress(item)}
       />
 
-      {zoomLevel < SHOW_LABEL_ZOOM_THRESHOLD && (
+      {showBuildingLabel && (
         <PolygonMarker
           center={center}
           label={item.buildingShortCode}

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -411,7 +411,7 @@ const renderPolygonItem = (
   selectedBuildingId: string | null,
   currentBuildingId: string | null,
   onPolygonPress: (item: PolygonRenderItem) => void,
-  zoomLevel:number,
+  zoomLevel: number,
 ) => {
   const theme = POLYGON_THEME[item.campus];
   const isSelected = item.buildingId === selectedBuildingId;
@@ -436,13 +436,13 @@ const renderPolygonItem = (
         onPress={() => onPolygonPress(item)}
       />
 
- {zoomLevel < SHOW_LABEL_ZOOM_THRESHOLD && (
-  <PolygonMarker
-    center={center}
-    label={item.buildingShortCode}
-    backgroundColor={theme.labelFill}
-  />
-)}
+      {zoomLevel < SHOW_LABEL_ZOOM_THRESHOLD && (
+        <PolygonMarker
+          center={center}
+          label={item.buildingShortCode}
+          backgroundColor={theme.labelFill}
+        />
+      )}
     </Fragment>
   );
 };
@@ -452,11 +452,13 @@ const renderPolygonItems = (
   selectedBuildingId: string | null,
   currentBuildingId: string | null,
   onPolygonPress: (item: PolygonRenderItem) => void,
-  zoomLevel:number,
+  zoomLevel: number,
 ) => {
   const elements: React.ReactElement[] = [];
   for (const item of polygonItems) {
-    elements.push(renderPolygonItem(item, selectedBuildingId, currentBuildingId, onPolygonPress, zoomLevel));
+    elements.push(
+      renderPolygonItem(item, selectedBuildingId, currentBuildingId, onPolygonPress, zoomLevel),
+    );
   }
   return elements;
 };
@@ -735,17 +737,23 @@ function MapScreen({
       tracksViewChanges={false}
     />
   ) : null;
-const initialRegion = getCampusRegion('SGW');
+  const initialRegion = getCampusRegion('SGW');
 
-const [zoomLevel, setZoomLevel] = useState(initialRegion.latitudeDelta);
-const handleRegionChange = useCallback((region: any) => {
-  setZoomLevel(region.latitudeDelta);
-}, []);
+  const [zoomLevel, setZoomLevel] = useState(initialRegion.latitudeDelta);
+  const handleRegionChange = useCallback((region: any) => {
+    setZoomLevel(region.latitudeDelta);
+  }, []);
 
   const renderedPolygons = useMemo(
     () =>
-      renderPolygonItems(polygonItems, selectedBuildingId, currentBuildingId, handlePolygonPress, zoomLevel),
-    [currentBuildingId, handlePolygonPress, polygonItems, selectedBuildingId,zoomLevel],
+      renderPolygonItems(
+        polygonItems,
+        selectedBuildingId,
+        currentBuildingId,
+        handlePolygonPress,
+        zoomLevel,
+      ),
+    [currentBuildingId, handlePolygonPress, polygonItems, selectedBuildingId, zoomLevel],
   );
 
   const mapProps = {
@@ -772,7 +780,12 @@ const handleRegionChange = useCallback((region: any) => {
   };
   return (
     <View style={styles.container}>
-      <MapView {...mapProps} toolbarEnabled={false} moveOnMarkerPress={false} onRegionChangeComplete={handleRegionChange}>
+      <MapView
+        {...mapProps}
+        toolbarEnabled={false}
+        moveOnMarkerPress={false}
+        onRegionChangeComplete={handleRegionChange}
+      >
         {renderedPolygons}
         {selectedMarker}
         {showRoute && (

--- a/mobile/src/screens/MapScreen.tsx
+++ b/mobile/src/screens/MapScreen.tsx
@@ -75,7 +75,8 @@ const ROUTE_LINE_WIDTH = 6;
 const WALKING_DASH_PATTERN = [12, 8];
 const ROUTE_POLYLINE_STROKE_PROPS = { strokeColor: ROUTE_LINE_COLOR } as const;
 const POLYGON_PRESS_GUARD_RESET_DELAY_MS = 0;
-
+//EDIT THIS VALUE TO ADJUST HOW MUCH ZOOM IS REQUIRED TO SHOW BUILDING LABELS
+const SHOW_LABEL_ZOOM_THRESHOLD = 0.0086;
 type PolygonPressGuardTimeoutRef = {
   current: ReturnType<typeof setTimeout> | null;
 };
@@ -410,6 +411,7 @@ const renderPolygonItem = (
   selectedBuildingId: string | null,
   currentBuildingId: string | null,
   onPolygonPress: (item: PolygonRenderItem) => void,
+  zoomLevel:number,
 ) => {
   const theme = POLYGON_THEME[item.campus];
   const isSelected = item.buildingId === selectedBuildingId;
@@ -434,11 +436,13 @@ const renderPolygonItem = (
         onPress={() => onPolygonPress(item)}
       />
 
-      <PolygonMarker
-        center={center}
-        label={item.buildingShortCode}
-        backgroundColor={theme.labelFill}
-      />
+ {zoomLevel < SHOW_LABEL_ZOOM_THRESHOLD && (
+  <PolygonMarker
+    center={center}
+    label={item.buildingShortCode}
+    backgroundColor={theme.labelFill}
+  />
+)}
     </Fragment>
   );
 };
@@ -448,10 +452,11 @@ const renderPolygonItems = (
   selectedBuildingId: string | null,
   currentBuildingId: string | null,
   onPolygonPress: (item: PolygonRenderItem) => void,
+  zoomLevel:number,
 ) => {
   const elements: React.ReactElement[] = [];
   for (const item of polygonItems) {
-    elements.push(renderPolygonItem(item, selectedBuildingId, currentBuildingId, onPolygonPress));
+    elements.push(renderPolygonItem(item, selectedBuildingId, currentBuildingId, onPolygonPress, zoomLevel));
   }
   return elements;
 };
@@ -730,11 +735,17 @@ function MapScreen({
       tracksViewChanges={false}
     />
   ) : null;
+const initialRegion = getCampusRegion('SGW');
+
+const [zoomLevel, setZoomLevel] = useState(initialRegion.latitudeDelta);
+const handleRegionChange = useCallback((region: any) => {
+  setZoomLevel(region.latitudeDelta);
+}, []);
 
   const renderedPolygons = useMemo(
     () =>
-      renderPolygonItems(polygonItems, selectedBuildingId, currentBuildingId, handlePolygonPress),
-    [currentBuildingId, handlePolygonPress, polygonItems, selectedBuildingId],
+      renderPolygonItems(polygonItems, selectedBuildingId, currentBuildingId, handlePolygonPress, zoomLevel),
+    [currentBuildingId, handlePolygonPress, polygonItems, selectedBuildingId,zoomLevel],
   );
 
   const mapProps = {
@@ -761,7 +772,7 @@ function MapScreen({
   };
   return (
     <View style={styles.container}>
-      <MapView {...mapProps} toolbarEnabled={false} moveOnMarkerPress={false}>
+      <MapView {...mapProps} toolbarEnabled={false} moveOnMarkerPress={false} onRegionChangeComplete={handleRegionChange}>
         {renderedPolygons}
         {selectedMarker}
         {showRoute && (


### PR DESCRIPTION
## Summary
This PR handles a suggestion by our PO to ensure that labels are hidden when zoomed out and only visible when zoomed in enough
![task4 7 1](https://github.com/user-attachments/assets/06c3a757-2714-4d35-a9b8-bd670f0932be)

## Changes
- Edited ```MapScreen.tsx``` to added boolean logic to only show building labels when zoomed in at 0.086 zoom level

## How to Test
1. Run Application
2. Zoom in to see building labels
3. Zoom out to verify if they are hidden

## Notes
- Labels  needs animation when transitioning states

## Checklist
- [x] Builds/runs locally (or via Expo Go / emulator)
- [x] Meets acceptance criteria for the linked task/user story
- [x] Lint/format checks pass (if configured)
- [x] Tests added/updated (if applicable)
- [x] Screenshots included (for UI changes)
- [x] Ready to squash & merge
