### PR TITLE
BUG-4.1.1: Indoor top controls are blocked by the phone status bar on the deadzone

### DIFF
--- a/mobile/src/components/indoor/IndoorControls.tsx
+++ b/mobile/src/components/indoor/IndoorControls.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity, View, Text } from 'react-native';
+import { TouchableOpacity, View, Text, Platform, StatusBar } from 'react-native';
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import styles from '../../styles/IndoorControls.styles';
 import type { BuildingShape } from '../../types/BuildingShape';
@@ -28,8 +28,15 @@ const IndoorControls = ({
   const openBuildingList = () => {
     openAvailableBuildings();
   };
+
+  const controlsTopOffset = Platform.select({
+    ios: 56,
+    android: (StatusBar.currentHeight ?? 24) + 16,
+    default: 24,
+  });
+
   return (
-    <View testID="indoor-controls" style={styles.overlayRow}>
+    <View testID="indoor-controls" style={[styles.overlayRow, { top: controlsTopOffset ?? 24 }]}>
       {/* Floor selector */}
       <View style={styles.floorSelector}>
         <TouchableOpacity testID="floor-up" style={styles.floorArrowButton} onPress={onFloorUp}>

--- a/mobile/src/styles/IndoorControls.styles.ts
+++ b/mobile/src/styles/IndoorControls.styles.ts
@@ -14,11 +14,11 @@ const styles = StyleSheet.create({
   // ─── Root overlay container ───────────────────────────────────────────────
   overlayRow: {
     position: 'absolute',
-    top: 20,
+    top: 0,
     left: 0,
     right: 0,
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     justifyContent: 'space-between',
     paddingHorizontal: 12,
     zIndex: 10,
@@ -31,7 +31,6 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     paddingVertical: 4,
     paddingHorizontal: 6,
-    marginTop: -20,
     gap: 2,
     ...SHADOW,
   },
@@ -56,7 +55,6 @@ const styles = StyleSheet.create({
   // ─── Building name pill (centre) ─────────────────────────────────────────
   buildingNamePill: {
     flex: 1,
-    marginTop: -70,
     marginHorizontal: 10,
     backgroundColor: '#5a3037',
     borderRadius: 8,


### PR DESCRIPTION
# Summary
This PR fixes BUG-4.1.1 by moving indoor top controls out of the status-bar/cutout dead zone so all top actions remain tappable on notched devices.

It also includes a small reliability adjustment to avoid safe-area context runtime crashes in screens that are not wrapped with `SafeAreaProvider`.

## Changes
- Adjusted indoor top-controls positioning logic in `mobile/src/components/indoor/IndoorControls.tsx`.
- Replaced static top placement with platform-aware top offset:
- iOS: `56`
- Android: `StatusBar.currentHeight + 16`
- Fallback: `24`
- Removed negative top offsets that pushed controls into unsafe areas in `mobile/src/styles/IndoorControls.styles.ts`.
- Updated overlay alignment to keep the control row stable when shifted down.

## Tests Added/Updated
- No tests were added or updated for this UI positioning fix.

## How to Test

### Running the application
1. `cd mobile`
2. `npm install`
3. Run iOS app (`npm run ios` or your usual Expo iOS command).
4. Open indoor map view.
5. Verify the 4 top controls are below the status bar/cutout and all are tappable:
- floor up
- floor down
- building selector
- right-side action buttons

### Running checks
1. `npm run lint`

## Before the bugfix
<img width="auto" height="700" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-03-26 at 21 32 33" src="https://github.com/user-attachments/assets/5fbf2d5b-637e-45ff-ae60-d4b22b04617d" />

## After the bugfix:
<img width="auto" height="700" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-03-26 at 21 36 43" src="https://github.com/user-attachments/assets/660ef9e0-bf88-48de-b914-a25eb4870879" />



## Notes
- This is a UI placement fix with no intended product-scope expansion.
- Lint runs successfully; there is 1 pre-existing warning in test code (`TransitPlanDetails.test.tsx`) unrelated to this change.
- No behavior changes outside indoor top-controls positioning.

## Checklist
- [ ] Builds/runs locally (manual app verification)
- [x] Implements BUG-4.1.1 indoor control accessibility fix
- [x] Keeps top indoor controls outside status-bar/cutout dead zone
- [x] Prevents safe-area-context render crash in this component path
- [x] Lint checks run (`npm run lint`)
- [ ] Test checks pass (`npm test -- --watchman=false`)
- [ ] Coverage checks pass (`npm run test:coverage -- --watchman=false`)
- [ ] Screenshots/GIF included (if required by reviewers)
- [x] Ready for review
