### PR TITLE
BUG-4.4.3: Duplicate X Icon for Reset back to Default for Floor List Card

### DIFF
--- a/mobile/__test__/HybridDirectionsDetails.test.tsx
+++ b/mobile/__test__/HybridDirectionsDetails.test.tsx
@@ -105,6 +105,26 @@ describe('HybridDirectionsDetails', () => {
     expect(onPressGo).toHaveBeenCalledTimes(1);
   });
 
+  test('uses distinct reset and close header affordances', () => {
+    const { getByLabelText, getByText } = render(
+      <HybridDirectionsDetails
+        onClose={jest.fn()}
+        onClear={jest.fn()}
+        startLabel="H-811"
+        destinationLabel="VE-1.615"
+        selectedIndoorMode="walking"
+        selectedOutdoorMode="walking"
+        onIndoorModeChange={jest.fn()}
+        onOutdoorModeChange={jest.fn()}
+      />,
+    );
+
+    expect(getByLabelText('Clear route')).toBeTruthy();
+    expect(getByLabelText('Close directions')).toBeTruthy();
+    expect(getByText('refresh-outline')).toBeTruthy();
+    expect(getByText('close-outline')).toBeTruthy();
+  });
+
   test('renders the hybrid error message instead of the default subtitle when provided', () => {
     const { getByTestId, queryByText } = render(
       <HybridDirectionsDetails

--- a/mobile/__test__/IndoorDirectionDetails.test.tsx
+++ b/mobile/__test__/IndoorDirectionDetails.test.tsx
@@ -5,8 +5,14 @@ import IndoorDirectionDetails from '../src/components/indoor/IndoorDirectionDeta
 /* ---------- MOCKS ---------- */
 
 jest.mock('@expo/vector-icons', () => ({
-  Ionicons: 'Ionicons',
-  FontAwesome: 'FontAwesome',
+  Ionicons: ({ name }: { name: string }) => {
+    const { Text } = require('react-native');
+    return <Text>{name}</Text>;
+  },
+  FontAwesome: ({ name }: { name: string }) => {
+    const { Text } = require('react-native');
+    return <Text>{name}</Text>;
+  },
 }));
 
 jest.mock('react-native-paper', () => ({
@@ -23,6 +29,7 @@ describe('IndoorDirectionDetails FULL COVERAGE', () => {
 
     expect(getByText(/Directions/i)).toBeTruthy();
     expect(getByTestId('directions-close-button')).toBeTruthy();
+    expect(getByText('close-sharp')).toBeTruthy();
   });
 
   it('shows fallback text when start/destination are null', () => {
@@ -53,6 +60,20 @@ describe('IndoorDirectionDetails FULL COVERAGE', () => {
     fireEvent.press(getByTestId('directions-close-button'));
 
     expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the turning-arrow icon for clearing the route', () => {
+    const { getByLabelText, getByText } = render(
+      <IndoorDirectionDetails
+        onClose={jest.fn()}
+        onClear={jest.fn()}
+        startRoom={null}
+        destinationRoom={null}
+      />,
+    );
+
+    expect(getByLabelText('Clear route')).toBeTruthy();
+    expect(getByText('refresh-outline')).toBeTruthy();
   });
 
   it('calls onPressStart and onPressDestination', () => {

--- a/mobile/src/components/HybridDirectionsDetails.tsx
+++ b/mobile/src/components/HybridDirectionsDetails.tsx
@@ -201,15 +201,17 @@ export default function HybridDirectionsDetails({
             <TouchableOpacity
               testID="hybrid-clear-button"
               style={directionDetailsStyles.iconButton}
+              accessibilityLabel="Clear route"
               onPress={onClear}
             >
-              <Ionicons name="close-sharp" size={22} color="#fff" />
+              <Ionicons name="refresh-outline" size={22} color="#fff" />
             </TouchableOpacity>
           ) : null}
 
           <TouchableOpacity
             testID="hybrid-directions-close-button"
             style={directionDetailsStyles.iconButton}
+            accessibilityLabel="Close directions"
             onPress={onClose}
           >
             <Ionicons name="close-outline" size={25} color="#fff" />

--- a/mobile/src/components/indoor/IndoorDirectionDetails.tsx
+++ b/mobile/src/components/indoor/IndoorDirectionDetails.tsx
@@ -116,9 +116,10 @@ export default function IndoorDirectionDetails({
           <TouchableOpacity
             testID="clear-button"
             style={directionDetailsStyles.iconButton}
+            accessibilityLabel="Clear route"
             onPress={onClear}
           >
-            <Ionicons name="close-sharp" size={22} color="#fff" />
+            <Ionicons name="refresh-outline" size={22} color="#fff" />
           </TouchableOpacity>
 
           <TouchableOpacity
@@ -126,7 +127,7 @@ export default function IndoorDirectionDetails({
             style={directionDetailsStyles.iconButton}
             onPress={onClose}
           >
-            <Ionicons name="chevron-down-outline" size={25} color="#fff" />
+            <Ionicons name="close-sharp" size={25} color="#fff" />
           </TouchableOpacity>
         </View>
       </View>


### PR DESCRIPTION
## Summary
Addresses [`BUG-4.4.3: Duplicate X Icon for Reset back to Default for Floor List Card`](#290) by making the hybrid directions panel use a distinct reset icon for clearing route fields, so it no longer looks identical to the close action.

## Changes
- Replaced the left header action in the hybrid directions panel from an `X` icon to `refresh-outline` to better communicate “clear/reset route”.
- Added explicit accessibility labels for the two header actions: `Clear route` and `Close directions`.
- Added a component test to verify the reset and close affordances stay visually and semantically distinct.

## How to Test
1. Launch the mobile app and open a route that shows the hybrid directions panel in indoor directions.
2. Check the top-right header actions and verify the left button shows a reset-style icon while the right button remains the close icon.
3. Tap the left action and confirm it clears the start/destination fields; tap the right action and confirm it closes the panel. Also run `npm test -- --runInBand HybridDirectionsDetails.test.tsx`.

https://github.com/user-attachments/assets/0217ecff-dffa-48e2-9d70-25fc4f1bd2c9

## Notes
- This change not alter the underlying reset or close behaviour.


## Checklist
- [ ] Builds/runs locally (or via Expo Go / emulator)
- [ ] Meets acceptance criteria for the linked task/user story
- [ ] Lint/format checks pass (if configured)
- [ ] Tests added/updated (if applicable)
- [ ] Screenshots included (for UI changes)
- [ ] Ready to squash & merge
