### PR TITLE
US-6.4: refac - Unify SearchSheet + Support Outdoor-Indoor Navigation

### DIFF
--- a/mobile/__test__/BottomSheet.test.tsx
+++ b/mobile/__test__/BottomSheet.test.tsx
@@ -157,6 +157,7 @@ jest.mock('@gorhom/bottom-sheet', () => {
       (
         props: {
           children: any;
+          snapPoints?: string[];
           onClose?: () => void;
           onAnimate?: (from: number, to: number) => void;
         },
@@ -173,6 +174,9 @@ jest.mock('@gorhom/bottom-sheet', () => {
 
         return (
           <View testID="bottom-sheet">
+            <Text testID="bottom-sheet-snap-points">
+              {Array.isArray(props.snapPoints) ? props.snapPoints.join(',') : ''}
+            </Text>
             <TouchableOpacity testID="trigger-on-close" onPress={props.onClose}>
               <Text>Trigger Close</Text>
             </TouchableOpacity>
@@ -426,9 +430,11 @@ jest.mock('../src/components/SearchSheet', () => {
     calendarGoErrorMessage,
     onSelectRoom,
     searchMode,
+    searchSessionId,
   }: any) => (
     <View testID="search-sheet">
       <Text testID="search-mode-state">{searchMode ?? 'buildings'}</Text>
+      <Text testID="search-session-id-state">{searchSessionId ?? 0}</Text>
       <TouchableOpacity
         testID="press-building-in-search"
         onPress={() => onPressBuilding(mockSameBuildingSearchResult)}
@@ -1401,6 +1407,38 @@ describe('BottomSheet', () => {
     fireEvent.press(getByTestId('press-destination'));
 
     expect(getByTestId('search-sheet')).toBeTruthy();
+  });
+
+  test('internal building search reuses the standard search snap points instead of the directions snap profile', async () => {
+    const { getByTestId } = render(
+      <BottomSlider {...defaultProps} ref={createRef()} selectedBuilding={mockBuildings[0]} />,
+    );
+
+    await pressAndFlush(getByTestId('on-show-directions-as-destination'));
+    expect(getByTestId('bottom-sheet-snap-points').props.children).toContain('26%');
+
+    fireEvent.press(getByTestId('press-start'));
+
+    expect(getByTestId('search-sheet')).toBeTruthy();
+    expect(getByTestId('bottom-sheet-snap-points').props.children).toBe('22%,29%,47%,75%');
+  });
+
+  test('reopening internal search after a building selection starts a fresh search session', async () => {
+    const { getByTestId } = render(
+      <BottomSlider {...defaultProps} ref={createRef()} selectedBuilding={mockBuildings[0]} />,
+    );
+
+    await pressAndFlush(getByTestId('on-show-directions-as-destination'));
+    fireEvent.press(getByTestId('press-start'));
+
+    const firstSearchSessionId = Number(getByTestId('search-session-id-state').props.children);
+
+    await pressAndFlush(getByTestId('press-building-in-search'));
+    fireEvent.press(getByTestId('press-destination'));
+
+    const secondSearchSessionId = Number(getByTestId('search-session-id-state').props.children);
+
+    expect(secondSearchSessionId).toBeGreaterThan(firstSearchSessionId);
   });
 
   test('selecting a building from internal search returns to directions view and keeps panel at 52%', async () => {

--- a/mobile/__test__/BottomSheet.test.tsx
+++ b/mobile/__test__/BottomSheet.test.tsx
@@ -1088,7 +1088,7 @@ describe('BottomSheet', () => {
     expect(getByTestId('indoor-direction-details')).toBeTruthy();
 
     fireEvent.press(getByTestId('indoor-press-start'));
-    expect(getByTestId('search-mode-state').props.children).toBe('rooms');
+    expect(getByTestId('search-mode-state').props.children).toBe('mixed');
     await pressAndFlush(getByTestId('select-room-in-search'));
 
     expect(getByTestId('indoor-direction-details')).toBeTruthy();
@@ -1330,11 +1330,30 @@ describe('BottomSheet', () => {
     expect(queryByTestId('indoor-navigation-details')).toBeNull();
   });
 
-  test('room to building across different buildings shows hybrid guidance and disables GO', async () => {
+  test('room to building across different buildings starts the staged flow with only an origin indoor leg', async () => {
     const ref = createRef<BottomSliderHandle>();
     const { getByTestId, queryByTestId } = render(
       <BottomSlider {...defaultProps} ref={ref} selectedBuilding={null} isIndoor={true} />,
     );
+    crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow.mockReturnValueOnce({
+      ok: true,
+      flow: {
+        startRoomEndpoint: mockSameBuildingRoom,
+        destinationRoomEndpoint: null,
+        originBuilding: mockSameBuildingSearchResult,
+        destinationBuilding: mockOtherBuildingSearchResult,
+        originTransferPoint: {
+          buildingKey: 'H',
+          campus: 'SGW',
+          accessNodeId: 'Hall_F1_building_entry_exit_3',
+          outdoorCoords: { latitude: 45.497092, longitude: -73.5788 },
+          accessible: true,
+        },
+        destinationTransferPoint: null,
+        outdoorMode: 'walking',
+        currentStage: 'origin_indoor',
+      },
+    });
 
     await act(async () => {
       ref.current?.openIndoorDirections();
@@ -1350,15 +1369,119 @@ describe('BottomSheet', () => {
     expect(getByTestId('hybrid-directions-details')).toBeTruthy();
     expect(getByTestId('hybrid-start-label').props.children).toBe('H-811');
     expect(getByTestId('hybrid-destination-label').props.children).toBe('EV Building');
-    expect(getByTestId('hybrid-summary-message').props.children).toBe(
-      'Staged cross-building guidance currently supports room-to-room routes. Choose a room for both endpoints to continue.',
-    );
-    expect(getByTestId('hybrid-go-button').props.onPress).toBeUndefined();
     expect(queryByTestId('indoor-direction-details')).toBeNull();
 
     await pressAndFlush(getByTestId('hybrid-go-button'));
 
-    expect(crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow).not.toHaveBeenCalled();
+    expect(crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startRoom: mockSameBuildingRoom,
+        destinationBuilding: mockOtherBuildingSearchResult,
+      }),
+    );
+    expect(getByTestId('indoor-navigation-details')).toBeTruthy();
+    expect(getByTestId('indoor-stage-action-button')).toBeTruthy();
+  });
+
+  test('building to room across different buildings starts directly in outdoor directions and keeps the destination indoor CTA', async () => {
+    const ref = createRef<BottomSliderHandle>();
+    const { getByTestId, queryByTestId } = render(
+      <BottomSlider {...defaultProps} ref={ref} selectedBuilding={mockBuildings[0]} />,
+    );
+    crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow.mockReturnValueOnce({
+      ok: true,
+      flow: {
+        startRoomEndpoint: null,
+        destinationRoomEndpoint: mockOtherBuildingRoom,
+        originBuilding: mockSameBuildingSearchResult,
+        destinationBuilding: mockOtherBuildingSearchResult,
+        originTransferPoint: null,
+        destinationTransferPoint: {
+          buildingKey: 'VE',
+          campus: 'LOYOLA',
+          accessNodeId: 'VE_F1_building_entry_exit_6',
+          outdoorCoords: { latitude: 45.459026, longitude: -73.638606 },
+          accessible: true,
+        },
+        outdoorMode: 'walking',
+        currentStage: 'outdoor',
+      },
+    });
+
+    await pressAndFlush(getByTestId('on-show-directions-as-destination'));
+    fireEvent.press(getByTestId('press-start'));
+    await pressAndFlush(getByTestId('press-building-in-search'));
+    fireEvent.press(getByTestId('press-destination'));
+    await pressAndFlush(getByTestId('select-room-in-search-other-building'));
+
+    expect(getByTestId('hybrid-directions-details')).toBeTruthy();
+
+    await pressAndFlush(getByTestId('hybrid-go-button'));
+
+    expect(crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startBuilding: mockSameBuildingSearchResult,
+        destinationRoom: mockOtherBuildingRoom,
+      }),
+    );
+    expect(getByTestId('direction-details')).toBeTruthy();
+    expect(getByTestId('route-stage-action-button')).toBeTruthy();
+    expect(queryByTestId('indoor-navigation-details')).toBeNull();
+  });
+
+  test('selecting a room from the global outdoor search opens hybrid directions and can start the outdoor-to-indoor flow', async () => {
+    const SearchModeHarness = () => {
+      const [mode, setMode] = React.useState<'search' | 'detail'>('search');
+      return (
+        <BottomSlider
+          {...defaultProps}
+          ref={createRef()}
+          selectedBuilding={null}
+          mode={mode}
+          currentBuilding={null}
+          userLocation={{ latitude: 45.497, longitude: -73.579 }}
+          onExitSearch={() => setMode('detail')}
+        />
+      );
+    };
+    const { getByTestId } = render(<SearchModeHarness />);
+    crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow.mockReturnValueOnce({
+      ok: true,
+      flow: {
+        startRoomEndpoint: null,
+        destinationRoomEndpoint: mockOtherBuildingRoom,
+        originBuilding: null,
+        destinationBuilding: mockOtherBuildingSearchResult,
+        originTransferPoint: null,
+        destinationTransferPoint: {
+          buildingKey: 'VE',
+          campus: 'LOYOLA',
+          accessNodeId: 'VE_F1_building_entry_exit_6',
+          outdoorCoords: { latitude: 45.459026, longitude: -73.638606 },
+          accessible: true,
+        },
+        outdoorMode: 'walking',
+        currentStage: 'outdoor',
+      },
+    });
+
+    expect(getByTestId('search-sheet')).toBeTruthy();
+    await pressAndFlush(getByTestId('select-room-in-search-other-building'));
+
+    expect(getByTestId('hybrid-directions-details')).toBeTruthy();
+    expect(getByTestId('hybrid-start-label').props.children).toBe('My Location');
+    expect(getByTestId('hybrid-destination-label').props.children).toBe('VE-1.615');
+
+    await pressAndFlush(getByTestId('hybrid-go-button'));
+
+    expect(crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startBuilding: null,
+        destinationRoom: mockOtherBuildingRoom,
+      }),
+    );
+    expect(getByTestId('direction-details')).toBeTruthy();
+    expect(getByTestId('route-stage-action-button')).toBeTruthy();
   });
 
   test('room to room in the same building keeps the existing indoor directions panel', async () => {

--- a/mobile/__test__/SearchSheet.test.tsx
+++ b/mobile/__test__/SearchSheet.test.tsx
@@ -251,13 +251,14 @@ describe('SearchSheet', () => {
     expect(onPoiCategoryChange).toHaveBeenCalledWith('depanneur');
   });
 
-  test('renders room results when search mode is rooms', () => {
-    const { getByTestId, queryByText } = render(
+  test('keeps the unified mixed results layout even when rooms mode is requested', () => {
+    const { getByTestId, getByText } = render(
       <SearchSheet buildings={mockBuildings} searchMode="rooms" />,
     );
 
+    expect(getByTestId('mixed-search-results')).toBeTruthy();
     expect(getByTestId('mock-room-list')).toBeTruthy();
-    expect(queryByText('Hall Building')).toBeNull();
+    expect(getByText('Hall Building')).toBeTruthy();
   });
 
   test('renders both room and building sections when search mode is mixed', () => {

--- a/mobile/__test__/SearchSheet.test.tsx
+++ b/mobile/__test__/SearchSheet.test.tsx
@@ -279,6 +279,28 @@ describe('SearchSheet', () => {
     expect(getByTestId('mock-room-list')).toBeTruthy();
   });
 
+  test('resets the mixed search state when a new search session starts', async () => {
+    const { getByTestId, queryByTestId, rerender } = render(
+      <SearchSheet buildings={mockBuildings} searchSessionId={1} />,
+    );
+
+    fireEvent.changeText(getByTestId('search-bar'), 'hall');
+    fireEvent.press(getByTestId('search-poi-options-toggle'));
+
+    expect(getByTestId('search-bar').props.value).toBe('hall');
+    expect(queryByTestId('search-poi-panel')).toBeTruthy();
+
+    rerender(<SearchSheet buildings={mockBuildings} searchSessionId={2} />);
+
+    await waitFor(() => {
+      expect(getByTestId('search-bar').props.value).toBe('');
+      expect(queryByTestId('search-poi-panel')).toBeNull();
+      expect(getByTestId('search-poi-options-toggle').props.accessibilityLabel).toBe(
+        'Open POI options',
+      );
+    });
+  });
+
   test('forwards room selection in mixed search mode', () => {
     const onSelectRoom = jest.fn();
     const { getByTestId } = render(

--- a/mobile/__test__/crossBuildingRouteFlow.test.ts
+++ b/mobile/__test__/crossBuildingRouteFlow.test.ts
@@ -137,6 +137,100 @@ describe('buildCrossBuildingRouteFlow', () => {
     );
   });
 
+  test('returns a staged flow for a room to building route', () => {
+    const result = buildCrossBuildingRouteFlow({
+      startRoom,
+      destinationBuilding: buildingMB,
+      buildings: [buildingH, buildingMB],
+      indoorTravelMode: 'walking',
+      outdoorMode: 'walking',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      flow: {
+        startRoomEndpoint: startRoom,
+        destinationRoomEndpoint: null,
+        originBuilding: buildingH,
+        destinationBuilding: buildingMB,
+        originTransferPoint,
+        destinationTransferPoint: null,
+        outdoorMode: 'walking',
+        currentStage: 'origin_indoor',
+      },
+    });
+    expect(findIndoorPath).toHaveBeenCalledTimes(1);
+    expect(findIndoorPath).toHaveBeenCalledWith(
+      [],
+      [],
+      startRoom.id,
+      originTransferPoint.accessNodeId,
+      {
+        accessibleOnly: false,
+        preferElevators: false,
+      },
+    );
+  });
+
+  test('returns a staged flow for a building to room route', () => {
+    const result = buildCrossBuildingRouteFlow({
+      startBuilding: buildingH,
+      destinationRoom,
+      buildings: [buildingH, buildingMB],
+      indoorTravelMode: 'walking',
+      outdoorMode: 'walking',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      flow: {
+        startRoomEndpoint: null,
+        destinationRoomEndpoint: destinationRoom,
+        originBuilding: buildingH,
+        destinationBuilding: buildingMB,
+        originTransferPoint: null,
+        destinationTransferPoint,
+        outdoorMode: 'walking',
+        currentStage: 'outdoor',
+      },
+    });
+    expect(findIndoorPath).toHaveBeenCalledTimes(1);
+    expect(findIndoorPath).toHaveBeenCalledWith(
+      [],
+      [],
+      destinationTransferPoint.accessNodeId,
+      destinationRoom.id,
+      {
+        accessibleOnly: false,
+        preferElevators: false,
+      },
+    );
+  });
+
+  test('returns a staged flow for a current-location to room route', () => {
+    const result = buildCrossBuildingRouteFlow({
+      destinationRoom,
+      buildings: [buildingH, buildingMB],
+      indoorTravelMode: 'walking',
+      outdoorMode: 'transit',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      flow: {
+        startRoomEndpoint: null,
+        destinationRoomEndpoint: destinationRoom,
+        originBuilding: null,
+        destinationBuilding: buildingMB,
+        originTransferPoint: null,
+        destinationTransferPoint,
+        outdoorMode: 'transit',
+        currentStage: 'outdoor',
+      },
+    });
+    expect(findIndoorPath).toHaveBeenCalledTimes(1);
+  });
+
   test('rejects same-building room pairs', () => {
     const result = buildCrossBuildingRouteFlow({
       startRoom,

--- a/mobile/__test__/useCrossBuildingRouteFlow.test.ts
+++ b/mobile/__test__/useCrossBuildingRouteFlow.test.ts
@@ -59,6 +59,20 @@ const baseFlow: CrossBuildingRouteFlow = {
   currentStage: 'origin_indoor',
 };
 
+const destinationIndoorOnlyFlow: CrossBuildingRouteFlow = {
+  ...baseFlow,
+  startRoomEndpoint: null,
+  originTransferPoint: null,
+  currentStage: 'outdoor',
+};
+
+const roomToBuildingOutdoorFlow: CrossBuildingRouteFlow = {
+  ...baseFlow,
+  destinationRoomEndpoint: null,
+  destinationTransferPoint: null,
+  currentStage: 'outdoor',
+};
+
 describe('useCrossBuildingRouteFlow reducer', () => {
   test('starts a new flow and clears any stale hybrid error or overrides', () => {
     const staleState = {
@@ -81,6 +95,20 @@ describe('useCrossBuildingRouteFlow reducer', () => {
     });
   });
 
+  test('starts an outdoor-first flow with the correct route overrides already applied', () => {
+    expect(
+      crossBuildingRouteFlowReducer(initialCrossBuildingRouteFlowState, {
+        type: 'start_flow',
+        flow: destinationIndoorOnlyFlow,
+      }),
+    ).toEqual({
+      flow: destinationIndoorOnlyFlow,
+      hybridRouteErrorMessage: null,
+      routeOriginOverride: null,
+      routeDestinationOverride: baseFlow.destinationTransferPoint!.outdoorCoords,
+    });
+  });
+
   test('advances the flow to outdoor and derives outdoor route overrides', () => {
     const state = crossBuildingRouteFlowReducer(initialCrossBuildingRouteFlowState, {
       type: 'start_flow',
@@ -97,8 +125,8 @@ describe('useCrossBuildingRouteFlow reducer', () => {
         currentStage: 'outdoor',
       },
       hybridRouteErrorMessage: null,
-      routeOriginOverride: baseFlow.originTransferPoint.outdoorCoords,
-      routeDestinationOverride: baseFlow.destinationTransferPoint.outdoorCoords,
+      routeOriginOverride: baseFlow.originTransferPoint!.outdoorCoords,
+      routeDestinationOverride: baseFlow.destinationTransferPoint!.outdoorCoords,
     });
   });
 
@@ -110,8 +138,8 @@ describe('useCrossBuildingRouteFlow reducer', () => {
           currentStage: 'outdoor',
         },
         hybridRouteErrorMessage: null,
-        routeOriginOverride: baseFlow.originTransferPoint.outdoorCoords,
-        routeDestinationOverride: baseFlow.destinationTransferPoint.outdoorCoords,
+        routeOriginOverride: baseFlow.originTransferPoint!.outdoorCoords,
+        routeDestinationOverride: baseFlow.destinationTransferPoint!.outdoorCoords,
       },
       {
         type: 'advance_to_destination_indoor',
@@ -199,6 +227,24 @@ describe('getCrossBuildingRouteFlowPresentation', () => {
       indoorNavigationBuilding: originBuilding,
       indoorNavigationStartLabel: 'H-801',
       indoorNavigationDestinationLabel: 'H-805',
+      indoorStageActionLabel: undefined,
+      directionStageActionLabel: undefined,
+    });
+  });
+
+  test('hides the outdoor stage action when the staged route ends outdoors', () => {
+    expect(
+      getCrossBuildingRouteFlowPresentation({
+        flow: roomToBuildingOutdoorFlow,
+        fallbackBuilding: destinationBuilding,
+        fallbackStartLabel: 'H-811',
+        fallbackDestinationLabel: 'VE Building',
+      }),
+    ).toEqual({
+      hasDirectionsStageAction: false,
+      indoorNavigationBuilding: destinationBuilding,
+      indoorNavigationStartLabel: 'H-811',
+      indoorNavigationDestinationLabel: 'VE Building',
       indoorStageActionLabel: undefined,
       directionStageActionLabel: undefined,
     });

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -752,6 +752,7 @@ const HybridDirectionsView = ({
 type SearchContentProps = {
   calendarSliderMode: 'selection' | 'events' | null;
   isInternalSearch: boolean;
+  searchSessionId: number;
   selectedCalendarIds: string[];
   handleReselectCalendars: () => void;
   handleCloseUpcomingClassesSlider: () => void;
@@ -775,6 +776,7 @@ type SearchContentProps = {
 const SearchContent = ({
   calendarSliderMode,
   isInternalSearch,
+  searchSessionId,
   selectedCalendarIds,
   handleReselectCalendars,
   handleCloseUpcomingClassesSlider,
@@ -823,6 +825,7 @@ const SearchContent = ({
       onCalendarGoPress={handleCalendarGoFromSearch}
       calendarGoErrorMessage={calendarGoErrorMessage}
       searchMode={searchMode}
+      searchSessionId={searchSessionId}
       onSelectRoom={onSelectRoom}
       selectedPoiCategories={selectedPoiCategories}
       onPoiCategoryChange={onPoiCategoryChange}
@@ -836,6 +839,7 @@ const renderBottomSheetContent = (props: {
   isSearchActive: boolean;
   calendarSliderMode: 'selection' | 'events' | null;
   isInternalSearch: boolean;
+  searchSessionId: number;
   selectedCalendarIds: string[];
   handleReselectCalendars: () => void;
   handleCloseUpcomingClassesSlider: () => void;
@@ -1088,12 +1092,6 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
   ) => {
     const sheetRef = useRef<BottomSheet>(null);
     const [activeView, setActiveView] = useState<ViewType>('building');
-    const snapPoints = useMemo(() => {
-      if (activeView === 'navigation') return [...NAVIGATION_SNAP_POINTS];
-      if (activeView === 'directions') return [...DIRECTIONS_SNAP_POINTS];
-      if (activeView === 'shuttle-schedule') return [...SHUTTLE_SCHEDULE_SNAP_POINTS];
-      return [...DEFAULT_SNAP_POINTS];
-    }, [activeView]);
 
     const [startEndpoint, setStartEndpoint] = useState<MixedEndpoint | null>(null);
     const [destinationEndpoint, setDestinationEndpoint] = useState<MixedEndpoint | null>(null);
@@ -1201,6 +1199,24 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       setRouteRetryNonce((currentValue) => currentValue + 1);
     }, []);
 
+    const [searchFor, setSearchFor] = useState<SearchTarget>(null);
+    const [calendarSliderMode, setCalendarSliderMode] = useState<'selection' | 'events' | null>(
+      null,
+    );
+    const [selectedCalendarIds, setSelectedCalendarIds] = useState<string[]>([]);
+    const [calendarGoErrorMessage, setCalendarGoErrorMessage] = useState<string | null>(null);
+    const [searchSessionId, setSearchSessionId] = useState(0);
+    const isInternalSearch = searchFor !== null;
+    const isGlobalSearch = mode === 'search';
+    const isSearchActive = isInternalSearch || isGlobalSearch || calendarSliderMode !== null;
+    const snapPoints = useMemo(() => {
+      if (isSearchActive) return [...DEFAULT_SNAP_POINTS];
+      if (activeView === 'navigation') return [...NAVIGATION_SNAP_POINTS];
+      if (activeView === 'directions') return [...DIRECTIONS_SNAP_POINTS];
+      if (activeView === 'shuttle-schedule') return [...SHUTTLE_SCHEDULE_SNAP_POINTS];
+      return [...DEFAULT_SNAP_POINTS];
+    }, [activeView, isSearchActive]);
+
     const closeSheet = () => sheetRef.current?.close();
     const openSheet = (index: number = 0) => {
       if (activeView === 'directions') {
@@ -1244,29 +1260,26 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       () => getDirectionsPanelSnapPoint(travelMode, isCrossCampusRoute, hasDirectionsStageAction),
       [hasDirectionsStageAction, travelMode, isCrossCampusRoute],
     );
-
-    useEffect(() => {
-      if (activeView !== 'directions') return;
-
-      snapToDirectionsPanel(directionsPanelSnapPoint);
-    }, [activeView, directionsPanelSnapPoint, snapToDirectionsPanel]);
-
-    const [searchFor, setSearchFor] = useState<SearchTarget>(null);
-    const [calendarSliderMode, setCalendarSliderMode] = useState<'selection' | 'events' | null>(
-      null,
-    );
-    const [selectedCalendarIds, setSelectedCalendarIds] = useState<string[]>([]);
-    const [calendarGoErrorMessage, setCalendarGoErrorMessage] = useState<string | null>(null);
-    const isInternalSearch = searchFor !== null;
-    const isGlobalSearch = mode === 'search';
-    const isSearchActive = isInternalSearch || isGlobalSearch || calendarSliderMode !== null;
     const openSearchFor = useCallback(
       (target: SearchTarget) => {
         clearCrossBuildingRouteFlowState();
+        setSearchSessionId((previousSessionId) => previousSessionId + 1);
         setSearchFor(target);
       },
       [clearCrossBuildingRouteFlowState],
     );
+
+    useEffect(() => {
+      if (mode !== 'search') return;
+      setSearchSessionId((previousSessionId) => previousSessionId + 1);
+    }, [mode]);
+
+    useEffect(() => {
+      if (isSearchActive) return;
+      if (activeView !== 'directions') return;
+
+      snapToDirectionsPanel(directionsPanelSnapPoint);
+    }, [activeView, directionsPanelSnapPoint, isSearchActive, snapToDirectionsPanel]);
 
     const resolveViewForSelections = useCallback(
       (nextStart: MixedEndpoint | null, nextDestination: MixedEndpoint | null): ViewType => {
@@ -2172,6 +2185,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       isSearchActive,
       calendarSliderMode,
       isInternalSearch,
+      searchSessionId,
       selectedCalendarIds,
       handleReselectCalendars,
       handleCloseUpcomingClassesSlider,

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -55,6 +55,7 @@ import type { SearchMode } from '../types/SearchMode';
 import type { PoiCategory, PoiRangeKm } from '../types/Poi';
 import HybridDirectionsDetails from './HybridDirectionsDetails';
 import { getIndoorBuildingKeyFromShape } from '../utils/indoor/buildingKeys';
+import { getIndoorTransferPoint } from '../utils/indoor/indoorTransferPoints';
 import { buildCrossBuildingRouteFlow } from '../utils/indoor/crossBuildingRouteFlow';
 import {
   getCrossBuildingRouteFlowPresentation,
@@ -268,10 +269,17 @@ const isRoomEndpoint = (
   endpoint: MixedEndpoint | null,
 ): endpoint is Extract<MixedEndpoint, { kind: 'room' }> => endpoint?.kind === 'room';
 
+const isBuildingEndpoint = (
+  endpoint: MixedEndpoint | null,
+): endpoint is Extract<MixedEndpoint, { kind: 'building' }> => endpoint?.kind === 'building';
+
 const getEndpointLabel = (endpoint: MixedEndpoint | null): string | null => {
   if (!endpoint) return null;
   return endpoint.kind === 'room' ? endpoint.room.label : endpoint.building.name;
 };
+
+const getWaypointBuildingLabel = (building: Pick<BuildingShape, 'shortCode' | 'name'>) =>
+  building.shortCode ?? building.name;
 
 const getEndpointBuildingKey = (endpoint: MixedEndpoint | null): string | null => {
   if (!endpoint) return null;
@@ -291,6 +299,32 @@ const canStartCrossBuildingRoomRoute = (
   isRoomEndpoint(start) &&
   isRoomEndpoint(destination) &&
   start.room.buildingKey !== destination.room.buildingKey;
+
+const canStartMixedHybridRoute = ({
+  start,
+  destination,
+  hasOutdoorOrigin,
+}: {
+  start: MixedEndpoint | null;
+  destination: MixedEndpoint | null;
+  hasOutdoorOrigin: boolean;
+}) => {
+  if (canStartCrossBuildingRoomRoute(start, destination)) return true;
+
+  if (isRoomEndpoint(start) && isBuildingEndpoint(destination)) {
+    return start.room.buildingKey !== getEndpointBuildingKey(destination);
+  }
+
+  if (isBuildingEndpoint(start) && isRoomEndpoint(destination)) {
+    return getEndpointBuildingKey(start) !== destination.room.buildingKey;
+  }
+
+  if (!start && isRoomEndpoint(destination)) {
+    return hasOutdoorOrigin;
+  }
+
+  return false;
+};
 
 const shouldShowHybridDirectionsPanel = (
   start: MixedEndpoint | null,
@@ -327,14 +361,41 @@ const shouldShowHybridDirectionsPanel = (
 const getHybridRouteGuidanceMessage = (
   start: MixedEndpoint | null,
   destination: MixedEndpoint | null,
+  hasOutdoorOrigin: boolean,
 ) => {
-  if (!start || !destination) return null;
-  if (canStartCrossBuildingRoomRoute(start, destination)) return null;
-
-  if (start.kind !== destination.kind) {
-    return 'Staged cross-building guidance currently supports room-to-room routes. Choose a room for both endpoints to continue.';
+  if (canStartMixedHybridRoute({ start, destination, hasOutdoorOrigin })) {
+    return null;
   }
 
+  if (!isRoomEndpoint(start) && !isRoomEndpoint(destination)) {
+    return 'Choose at least one room to start a staged hybrid route.';
+  }
+
+  if (!start && isRoomEndpoint(destination) && !hasOutdoorOrigin) {
+    return 'Choose a starting point to continue.';
+  }
+
+  if (!destination) {
+    return 'Choose a destination to continue.';
+  }
+
+  return 'Choose endpoints in different buildings to start a staged hybrid route.';
+};
+
+const getOutdoorStartLabel = ({
+  startBuilding,
+  currentBuilding,
+  startLocationSnapshot,
+  userLocation,
+}: {
+  startBuilding: BuildingShape | null;
+  currentBuilding: BuildingShape | null;
+  startLocationSnapshot: UserCoords | null;
+  userLocation: UserCoords | null;
+}) => {
+  if (startBuilding?.name) return startBuilding.name;
+  if (currentBuilding?.name) return `${currentBuilding.name} (My Location)`;
+  if (startLocationSnapshot || userLocation) return 'My Location';
   return null;
 };
 
@@ -988,7 +1049,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       passOutdoorRoute,
       animatedPosition,
       onEnterBuilding,
-      isIndoor,
+      isIndoor: _isIndoor,
       enterIndoorView,
       onIndoorRouteChange,
       indoorPathSteps,
@@ -1185,6 +1246,14 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
 
     const resolveViewForSelections = useCallback(
       (nextStart: MixedEndpoint | null, nextDestination: MixedEndpoint | null): ViewType => {
+        const hasOutdoorOrigin = Boolean(
+          !nextStart && (startBuilding || startLocationSnapshot || currentBuilding || userLocation),
+        );
+
+        if (!nextStart && isRoomEndpoint(nextDestination) && hasOutdoorOrigin) {
+          return 'hybrid-directions';
+        }
+
         if (shouldShowHybridDirectionsPanel(nextStart, nextDestination)) {
           return 'hybrid-directions';
         }
@@ -1210,7 +1279,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
 
         return activeView;
       },
-      [activeView],
+      [activeView, currentBuilding, startBuilding, startLocationSnapshot, userLocation],
     );
 
     const syncIndoorRouteChange = useCallback(
@@ -1225,33 +1294,32 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
           return;
         }
 
+        if (isRoomEndpoint(nextStart) && isBuildingEndpoint(nextDestination)) {
+          const destinationBuildingKey = getIndoorBuildingKeyFromShape(nextDestination.building);
+          const transferPoint =
+            destinationBuildingKey === nextStart.room.buildingKey
+              ? getIndoorTransferPoint(destinationBuildingKey)
+              : null;
+          onIndoorRouteChange?.(nextStart.room.id, transferPoint?.accessNodeId ?? null);
+          return;
+        }
+
+        if (isBuildingEndpoint(nextStart) && isRoomEndpoint(nextDestination)) {
+          const startBuildingKey = getIndoorBuildingKeyFromShape(nextStart.building);
+          const transferPoint =
+            startBuildingKey === nextDestination.room.buildingKey
+              ? getIndoorTransferPoint(startBuildingKey)
+              : null;
+          onIndoorRouteChange?.(transferPoint?.accessNodeId ?? null, nextDestination.room.id);
+          return;
+        }
+
         onIndoorRouteChange?.(null, null);
       },
       [onIndoorRouteChange],
     );
 
-    const internalSearchMode = useMemo<SearchMode>(() => {
-      if (!isInternalSearch) {
-        return isIndoor ? 'rooms' : 'buildings';
-      }
-
-      if (activeView === 'hybrid-directions') {
-        return 'mixed';
-      }
-
-      if (activeView === 'indoor-directions') {
-        let oppositeEndpoint: MixedEndpoint | null = null;
-        if (searchFor === 'start') {
-          oppositeEndpoint = destinationEndpoint;
-        } else if (searchFor === 'destination') {
-          oppositeEndpoint = startEndpoint;
-        }
-
-        return isRoomEndpoint(oppositeEndpoint) ? 'mixed' : 'rooms';
-      }
-
-      return 'buildings';
-    }, [activeView, destinationEndpoint, isIndoor, isInternalSearch, searchFor, startEndpoint]);
+    const internalSearchMode = useMemo<SearchMode>(() => 'mixed', []);
 
     const applySelectionView = useCallback(
       (nextStart: MixedEndpoint | null, nextDestination: MixedEndpoint | null) => {
@@ -1270,14 +1338,34 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       (room: RoomNode) => {
         setHybridRouteErrorMessage(null);
         const nextEndpoint: MixedEndpoint = { kind: 'room', room };
-        const nextStart = searchFor === 'start' ? nextEndpoint : startEndpoint;
-        const nextDestination = searchFor === 'destination' ? nextEndpoint : destinationEndpoint;
+        const nextStart: MixedEndpoint | null =
+          searchFor === 'start'
+            ? nextEndpoint
+            : searchFor === null
+              ? currentBuilding
+                ? { kind: 'building' as const, building: currentBuilding }
+                : null
+              : startEndpoint;
+        const nextDestination: MixedEndpoint | null =
+          searchFor === 'start' ? destinationEndpoint : nextEndpoint;
 
         if (searchFor === 'start') {
           setStartRoom(room.label);
           setStartBuilding(null);
           setStartEndpoint(nextEndpoint);
         } else {
+          if (searchFor === null) {
+            clearCrossBuildingRouteFlowState();
+            setTravelMode('walking');
+            setHybridOutdoorTravelMode('walking');
+            setRouteStartSource('current');
+            setStartBuilding(currentBuilding ?? null);
+            setStartLocationSnapshot(currentBuilding ? null : userLocation);
+            setStartEndpoint(
+              currentBuilding ? { kind: 'building', building: currentBuilding } : null,
+            );
+            setStartRoom(null);
+          }
           setDestinationRoom(room.label);
           setDestinationBuilding(null);
           setDestinationEndpoint(nextEndpoint);
@@ -1287,7 +1375,16 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
         setCalendarSliderMode(null);
         applySelectionView(nextStart, nextDestination);
       },
-      [applySelectionView, destinationEndpoint, onExitSearch, searchFor, startEndpoint],
+      [
+        applySelectionView,
+        clearCrossBuildingRouteFlowState,
+        currentBuilding,
+        destinationEndpoint,
+        onExitSearch,
+        searchFor,
+        startEndpoint,
+        userLocation,
+      ],
     );
 
     const openCalendarSelectionSlider = useCallback(
@@ -1500,6 +1597,17 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       const nextEndpoint: MixedEndpoint = { kind: 'building', building };
       const nextStart = searchFor === 'start' ? nextEndpoint : startEndpoint;
       const nextDestination = searchFor === 'destination' ? nextEndpoint : destinationEndpoint;
+      const oppositeEndpoint = searchFor === 'start' ? destinationEndpoint : startEndpoint;
+      const oppositeRoomBuildingKey = isRoomEndpoint(oppositeEndpoint)
+        ? oppositeEndpoint.room.buildingKey
+        : null;
+      const buildingKey = getIndoorBuildingKeyFromShape(building);
+      const shouldUseIndoorWaypointLabel =
+        oppositeRoomBuildingKey !== null && oppositeRoomBuildingKey === buildingKey;
+      const buildingWaypointLabel = searchFor === 'start' ? 'Entrance' : 'Exit';
+      const buildingSelectionLabel = shouldUseIndoorWaypointLabel
+        ? `${getWaypointBuildingLabel(building)} ${buildingWaypointLabel}`
+        : building.name;
 
       passSelectedBuilding(building);
 
@@ -1507,11 +1615,11 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
         setRouteStartSource('manual');
         setStartBuilding(building);
         setStartLocationSnapshot(null);
-        setStartRoom(building.name);
+        setStartRoom(buildingSelectionLabel);
         setStartEndpoint(nextEndpoint);
       } else {
         setDestinationBuilding(building);
-        setDestinationRoom(building.name);
+        setDestinationRoom(buildingSelectionLabel);
         setDestinationEndpoint(nextEndpoint);
       }
 
@@ -1524,18 +1632,32 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
     const handleHybridGo = useCallback(() => {
       setHybridRouteErrorMessage(null);
 
-      if (!canStartCrossBuildingRoomRoute(startEndpoint, destinationEndpoint)) {
+      const hasOutdoorOrigin = Boolean(
+        !startEndpoint &&
+        (startBuilding || startLocationSnapshot || currentBuilding || userLocation),
+      );
+
+      if (
+        !canStartMixedHybridRoute({
+          start: startEndpoint,
+          destination: destinationEndpoint,
+          hasOutdoorOrigin,
+        })
+      ) {
         setHybridRouteErrorMessage(
-          getHybridRouteGuidanceMessage(startEndpoint, destinationEndpoint) ??
-            'Choose two rooms in different buildings to start a staged cross-building route.',
+          getHybridRouteGuidanceMessage(startEndpoint, destinationEndpoint, hasOutdoorOrigin) ??
+            'Choose endpoints in different buildings to start a staged hybrid route.',
         );
         return;
       }
-      if (!isRoomEndpoint(startEndpoint) || !isRoomEndpoint(destinationEndpoint)) return;
 
       const result = buildCrossBuildingRouteFlow({
-        startRoom: startEndpoint.room,
-        destinationRoom: destinationEndpoint.room,
+        startRoom: isRoomEndpoint(startEndpoint) ? startEndpoint.room : null,
+        startBuilding: isBuildingEndpoint(startEndpoint) ? startEndpoint.building : startBuilding,
+        destinationRoom: isRoomEndpoint(destinationEndpoint) ? destinationEndpoint.room : null,
+        destinationBuilding: isBuildingEndpoint(destinationEndpoint)
+          ? destinationEndpoint.building
+          : destinationBuilding,
         buildings,
         indoorTravelMode,
         outdoorMode: hybridOutdoorTravelMode,
@@ -1551,31 +1673,55 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       resetRouteState();
       startCrossBuildingRouteFlow(flow);
       setTravelMode(flow.outdoorMode);
-      setRouteStartSource('manual');
-      setStartLocationSnapshot(null);
+      setRouteStartSource(flow.originBuilding ? 'manual' : 'current');
+      setStartLocationSnapshot(
+        flow.originBuilding ? null : (startLocationSnapshot ?? userLocation),
+      );
       setStartBuilding(flow.originBuilding);
       setDestinationBuilding(flow.destinationBuilding);
-      passSelectedBuilding(flow.originBuilding);
-      onIndoorRouteChange?.(flow.startRoomEndpoint.id, flow.originTransferPoint.accessNodeId);
-      enterIndoorView();
-      onEnterBuilding(flow.originBuilding);
-      setActiveView('indoor-navigation');
-      requestAnimationFrame(() => {
-        sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
-      });
+      passSelectedBuilding(
+        flow.currentStage === 'origin_indoor' ? flow.originBuilding : flow.destinationBuilding,
+      );
+
+      if (
+        flow.currentStage === 'origin_indoor' &&
+        flow.startRoomEndpoint &&
+        flow.originTransferPoint &&
+        flow.originBuilding
+      ) {
+        onIndoorRouteChange?.(flow.startRoomEndpoint.id, flow.originTransferPoint.accessNodeId);
+        enterIndoorView();
+        onEnterBuilding(flow.originBuilding);
+        setActiveView('indoor-navigation');
+        requestAnimationFrame(() => {
+          sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
+        });
+        return;
+      }
+
+      onIndoorRouteChange?.(null, null);
+      resetRouteState();
+      onShowOutdoorMap?.();
+      setActiveView('directions');
     }, [
       buildings,
       clearCrossBuildingRouteFlowState,
+      currentBuilding,
+      destinationBuilding,
       destinationEndpoint,
       enterIndoorView,
       hybridOutdoorTravelMode,
       indoorTravelMode,
       onEnterBuilding,
       onIndoorRouteChange,
+      onShowOutdoorMap,
       passSelectedBuilding,
       resetRouteState,
+      startBuilding,
+      startLocationSnapshot,
       startCrossBuildingRouteFlow,
       startEndpoint,
+      userLocation,
     ]);
 
     const handleContinueToOutdoorDirections = useCallback(() => {
@@ -1602,7 +1748,12 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
     ]);
 
     const handleEnterDestinationBuilding = useCallback(() => {
-      if (!crossBuildingRouteFlow || crossBuildingRouteFlow.currentStage !== 'outdoor') {
+      if (
+        !crossBuildingRouteFlow ||
+        crossBuildingRouteFlow.currentStage !== 'outdoor' ||
+        !crossBuildingRouteFlow.destinationRoomEndpoint ||
+        !crossBuildingRouteFlow.destinationTransferPoint
+      ) {
         return;
       }
 
@@ -1915,10 +2066,30 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       },
     }));
 
-    const hybridStartLabel = getEndpointLabel(startEndpoint) ?? startRoom;
-    const hybridDestinationLabel = getEndpointLabel(destinationEndpoint) ?? destinationRoom;
-    const hybridSummaryMessage = getHybridRouteGuidanceMessage(startEndpoint, destinationEndpoint);
-    const hybridGoDisabled = !canStartCrossBuildingRoomRoute(startEndpoint, destinationEndpoint);
+    const hasHybridOutdoorOrigin = Boolean(
+      !startEndpoint && (startBuilding || startLocationSnapshot || currentBuilding || userLocation),
+    );
+    const hybridStartLabel =
+      getEndpointLabel(startEndpoint) ??
+      startRoom ??
+      getOutdoorStartLabel({
+        startBuilding,
+        currentBuilding,
+        startLocationSnapshot,
+        userLocation,
+      });
+    const hybridDestinationLabel =
+      getEndpointLabel(destinationEndpoint) ?? destinationRoom ?? destinationBuilding?.name ?? null;
+    const hybridSummaryMessage = getHybridRouteGuidanceMessage(
+      startEndpoint,
+      destinationEndpoint,
+      hasHybridOutdoorOrigin,
+    );
+    const hybridGoDisabled = !canStartMixedHybridRoute({
+      start: startEndpoint,
+      destination: destinationEndpoint,
+      hasOutdoorOrigin: hasHybridOutdoorOrigin,
+    });
 
     const renderedContent = renderBottomSheetContent({
       isSearchActive,

--- a/mobile/src/components/SearchSheet.tsx
+++ b/mobile/src/components/SearchSheet.tsx
@@ -3,7 +3,7 @@ import { Animated, Easing, Text, TouchableOpacity, View } from 'react-native';
 import { SearchBar } from 'react-native-elements';
 import { searchBuilding } from '../styles/SearchBuilding.styles';
 import { Ionicons } from '@expo/vector-icons';
-import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { BottomSheetScrollView, type BottomSheetScrollViewMethods } from '@gorhom/bottom-sheet';
 import { BuildingShape } from '../types/BuildingShape';
 import type { ListRenderItemInfo } from 'react-native';
 import type { SearchMode } from '../types/SearchMode';
@@ -28,6 +28,7 @@ type SearchBarProps = {
   onCalendarGoPress?: (nextClassEvent: GoogleCalendarEventItem | null) => void;
   calendarGoErrorMessage?: string | null;
   searchMode?: SearchMode;
+  searchSessionId?: number;
   onSelectRoom?: (room: RoomNode) => void;
   selectedPoiCategories?: PoiCategorySelection;
   onPoiCategoryChange?: React.Dispatch<React.SetStateAction<PoiCategorySelection>>;
@@ -46,6 +47,7 @@ export default function SearchSheet({
   onCalendarGoPress,
   calendarGoErrorMessage = null,
   searchMode: _searchMode = 'mixed',
+  searchSessionId = 0,
   onSelectRoom,
   selectedPoiCategories = [],
   onPoiCategoryChange,
@@ -64,6 +66,7 @@ export default function SearchSheet({
   const [hasOnlyUnsupportedNextClassEvents, setHasOnlyUnsupportedNextClassEvents] = useState(false);
   const nextClassRequestIdRef = useRef(0);
   const poiPanelAnimation = useRef(new Animated.Value(0)).current;
+  const resultsScrollViewRef = useRef<BottomSheetScrollViewMethods | null>(null);
 
   const nextClassLabel = useMemo(() => {
     if (isNextClassLoading) return 'Loading next class...';
@@ -223,6 +226,25 @@ export default function SearchSheet({
     };
   }, [isPoiPanelOpen, poiPanelAnimation]);
 
+  useEffect(() => {
+    setSearch('');
+    setIsPoiPanelOpen(false);
+    setShouldRenderPoiPanel(false);
+    poiPanelAnimation.stopAnimation();
+    poiPanelAnimation.setValue(0);
+
+    const frame = requestAnimationFrame(() => {
+      resultsScrollViewRef.current?.scrollTo?.({
+        y: 0,
+        animated: false,
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, [poiPanelAnimation, searchSessionId]);
+
   const handleConnectCalendar = useCallback(async () => {
     setIsCalendarConnecting(true);
     setCalendarMessage(null);
@@ -359,6 +381,7 @@ export default function SearchSheet({
   const renderedSearchResults = useMemo(() => {
     return (
       <BottomSheetScrollView
+        ref={resultsScrollViewRef}
         testID="mixed-search-results"
         style={searchBuilding.scrollArea}
         contentContainerStyle={searchBuilding.scrollContent}

--- a/mobile/src/components/SearchSheet.tsx
+++ b/mobile/src/components/SearchSheet.tsx
@@ -3,10 +3,9 @@ import { Animated, Easing, Text, TouchableOpacity, View } from 'react-native';
 import { SearchBar } from 'react-native-elements';
 import { searchBuilding } from '../styles/SearchBuilding.styles';
 import { Ionicons } from '@expo/vector-icons';
-import { BottomSheetFlatList, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { BuildingShape } from '../types/BuildingShape';
 import type { ListRenderItemInfo } from 'react-native';
-import { roomListStyles as inDoorList } from '../styles/RoomList.Styles';
 import type { SearchMode } from '../types/SearchMode';
 import {
   clearGoogleCalendarSession,
@@ -37,9 +36,6 @@ type SearchBarProps = {
 };
 
 const SearchBarCompat = SearchBar as React.ComponentType<any>;
-const SEARCH_LIST_INITIAL_NUM_TO_RENDER = 12;
-const SEARCH_LIST_MAX_TO_RENDER_PER_BATCH = 12;
-const SEARCH_LIST_WINDOW_SIZE = 7;
 const POI_PANEL_ANIMATION_DURATION_MS = 1000;
 
 export default function SearchSheet({
@@ -49,7 +45,7 @@ export default function SearchSheet({
   selectedCalendarIds = [],
   onCalendarGoPress,
   calendarGoErrorMessage = null,
-  searchMode = 'buildings',
+  searchMode: _searchMode = 'mixed',
   onSelectRoom,
   selectedPoiCategory = null,
   onPoiCategoryChange,
@@ -321,9 +317,6 @@ export default function SearchSheet({
     }),
     [poiPanelAnimation],
   );
-  const showsRooms = searchMode === 'rooms' || searchMode === 'mixed';
-  const showsBuildings = searchMode === 'buildings' || searchMode === 'mixed';
-
   const renderBuildingItem = useCallback(
     ({ item }: ListRenderItemInfo<BuildingShape>) => (
       <TouchableOpacity
@@ -364,66 +357,27 @@ export default function SearchSheet({
   );
 
   const renderedSearchResults = useMemo(() => {
-    if (showsRooms && showsBuildings) {
-      return (
-        <BottomSheetScrollView
-          testID="mixed-search-results"
-          style={searchBuilding.scrollArea}
-          contentContainerStyle={searchBuilding.scrollContent}
-          showsVerticalScrollIndicator={true}
-        >
-          <Text testID="search-section-rooms" style={searchBuilding.sectionTitle}>
-            Rooms
-          </Text>
-          <View style={searchBuilding.mixedSectionContainer}>
-            <RoomList search={search} onSelectRoom={onSelectRoom} variant="static" />
-          </View>
-
-          <Text testID="search-section-buildings" style={searchBuilding.sectionTitle}>
-            Buildings
-          </Text>
-          <View style={searchBuilding.mixedSectionContainer}>{renderedBuildingResults}</View>
-        </BottomSheetScrollView>
-      );
-    }
-
-    if (showsRooms) {
-      return (
-        <BottomSheetScrollView
-          testID="rooms-search-results"
-          style={searchBuilding.scrollArea}
-          contentContainerStyle={searchBuilding.scrollContent}
-          showsVerticalScrollIndicator={true}
-        >
-          <RoomList search={search} onSelectRoom={onSelectRoom} variant="static" />
-        </BottomSheetScrollView>
-      );
-    }
-
     return (
-      <BottomSheetFlatList<BuildingShape>
-        data={filtered}
-        keyExtractor={(item: BuildingShape) => item.id}
-        contentContainerStyle={searchBuilding.listContent}
+      <BottomSheetScrollView
+        testID="mixed-search-results"
+        style={searchBuilding.scrollArea}
+        contentContainerStyle={searchBuilding.scrollContent}
         showsVerticalScrollIndicator={true}
-        initialNumToRender={SEARCH_LIST_INITIAL_NUM_TO_RENDER}
-        maxToRenderPerBatch={SEARCH_LIST_MAX_TO_RENDER_PER_BATCH}
-        windowSize={SEARCH_LIST_WINDOW_SIZE}
-        removeClippedSubviews={true}
-        keyboardShouldPersistTaps="handled"
-        ListEmptyComponent={<Text style={searchBuilding.emptyText}>No buildings found</Text>}
-        renderItem={renderBuildingItem}
-      />
+      >
+        <Text testID="search-section-rooms" style={searchBuilding.sectionTitle}>
+          Rooms
+        </Text>
+        <View style={searchBuilding.mixedSectionContainer}>
+          <RoomList search={search} onSelectRoom={onSelectRoom} variant="static" />
+        </View>
+
+        <Text testID="search-section-buildings" style={searchBuilding.sectionTitle}>
+          Buildings
+        </Text>
+        <View style={searchBuilding.mixedSectionContainer}>{renderedBuildingResults}</View>
+      </BottomSheetScrollView>
     );
-  }, [
-    filtered,
-    onSelectRoom,
-    renderedBuildingResults,
-    renderBuildingItem,
-    search,
-    showsBuildings,
-    showsRooms,
-  ]);
+  }, [onSelectRoom, renderedBuildingResults, search]);
 
   return (
     <View style={searchBuilding.screen}>
@@ -574,15 +528,7 @@ export default function SearchSheet({
       </TouchableOpacity>
       {calendarMessage ? <Text style={searchBuilding.authMessage}>{calendarMessage}</Text> : null}
 
-      <View
-        style={[
-          showsRooms && !showsBuildings
-            ? inDoorList.indoorContainer
-            : searchBuilding.buildingsContainer,
-        ]}
-      >
-        {renderedSearchResults}
-      </View>
+      <View style={searchBuilding.buildingsContainer}>{renderedSearchResults}</View>
     </View>
   );
 }

--- a/mobile/src/hooks/useCrossBuildingRouteFlow.ts
+++ b/mobile/src/hooks/useCrossBuildingRouteFlow.ts
@@ -59,8 +59,14 @@ export const crossBuildingRouteFlowReducer = (
       return {
         flow: action.flow,
         hybridRouteErrorMessage: null,
-        routeOriginOverride: null,
-        routeDestinationOverride: null,
+        routeOriginOverride:
+          action.flow.currentStage === 'outdoor'
+            ? (action.flow.originTransferPoint?.outdoorCoords ?? null)
+            : null,
+        routeDestinationOverride:
+          action.flow.currentStage === 'outdoor'
+            ? (action.flow.destinationTransferPoint?.outdoorCoords ?? null)
+            : null,
       };
     case 'advance_to_outdoor':
       if (!state.flow || state.flow.currentStage !== 'origin_indoor') return state;
@@ -71,11 +77,12 @@ export const crossBuildingRouteFlowReducer = (
           ...state.flow,
           currentStage: 'outdoor',
         },
-        routeOriginOverride: state.flow.originTransferPoint.outdoorCoords,
-        routeDestinationOverride: state.flow.destinationTransferPoint.outdoorCoords,
+        routeOriginOverride: state.flow.originTransferPoint?.outdoorCoords ?? null,
+        routeDestinationOverride: state.flow.destinationTransferPoint?.outdoorCoords ?? null,
       };
     case 'advance_to_destination_indoor':
       if (!state.flow || state.flow.currentStage !== 'outdoor') return state;
+      if (!state.flow.destinationRoomEndpoint || !state.flow.destinationTransferPoint) return state;
 
       return {
         ...state,
@@ -97,7 +104,11 @@ export const getCrossBuildingRouteFlowPresentation = ({
   fallbackStartLabel,
   fallbackDestinationLabel,
 }: CrossBuildingRouteFlowPresentationInput): CrossBuildingRouteFlowPresentation => {
-  if (flow?.currentStage === 'destination_indoor') {
+  if (
+    flow?.currentStage === 'destination_indoor' &&
+    flow.destinationRoomEndpoint &&
+    flow.destinationTransferPoint
+  ) {
     return {
       hasDirectionsStageAction: false,
       indoorNavigationBuilding: flow.destinationBuilding,
@@ -108,7 +119,7 @@ export const getCrossBuildingRouteFlowPresentation = ({
     };
   }
 
-  if (flow?.currentStage === 'origin_indoor') {
+  if (flow?.currentStage === 'origin_indoor' && flow.originBuilding && flow.startRoomEndpoint) {
     return {
       hasDirectionsStageAction: false,
       indoorNavigationBuilding: flow.originBuilding,
@@ -120,12 +131,19 @@ export const getCrossBuildingRouteFlowPresentation = ({
   }
 
   return {
-    hasDirectionsStageAction: flow?.currentStage === 'outdoor',
+    hasDirectionsStageAction:
+      flow?.currentStage === 'outdoor' &&
+      Boolean(flow.destinationRoomEndpoint && flow.destinationTransferPoint),
     indoorNavigationBuilding: fallbackBuilding,
     indoorNavigationStartLabel: fallbackStartLabel,
     indoorNavigationDestinationLabel: fallbackDestinationLabel,
     indoorStageActionLabel: undefined,
-    directionStageActionLabel: flow?.currentStage === 'outdoor' ? 'Enter Building' : undefined,
+    directionStageActionLabel:
+      flow?.currentStage === 'outdoor' &&
+      flow.destinationRoomEndpoint &&
+      flow.destinationTransferPoint
+        ? 'Enter Building'
+        : undefined,
   };
 };
 

--- a/mobile/src/types/CrossBuildingRoute.ts
+++ b/mobile/src/types/CrossBuildingRoute.ts
@@ -29,19 +29,21 @@ export type CrossBuildingRoomEndpoint = {
 };
 
 export type CrossBuildingRouteFlow = {
-  startRoomEndpoint: CrossBuildingRoomEndpoint;
-  destinationRoomEndpoint: CrossBuildingRoomEndpoint;
-  originBuilding: BuildingShape;
+  startRoomEndpoint: CrossBuildingRoomEndpoint | null;
+  destinationRoomEndpoint: CrossBuildingRoomEndpoint | null;
+  originBuilding: BuildingShape | null;
   destinationBuilding: BuildingShape;
-  originTransferPoint: IndoorTransferPoint;
-  destinationTransferPoint: IndoorTransferPoint;
+  originTransferPoint: IndoorTransferPoint | null;
+  destinationTransferPoint: IndoorTransferPoint | null;
   outdoorMode: RoutePlannerMode;
   currentStage: CrossBuildingRouteStage;
 };
 
 export type BuildCrossBuildingRouteFlowInput = {
-  startRoom: CrossBuildingRoomEndpoint;
-  destinationRoom: CrossBuildingRoomEndpoint;
+  startRoom?: CrossBuildingRoomEndpoint | null;
+  startBuilding?: BuildingShape | null;
+  destinationRoom?: CrossBuildingRoomEndpoint | null;
+  destinationBuilding?: BuildingShape | null;
   buildings: BuildingShape[];
   indoorTravelMode: IndoorRoutePlannerMode;
   outdoorMode: RoutePlannerMode;

--- a/mobile/src/utils/indoor/crossBuildingRouteFlow.ts
+++ b/mobile/src/utils/indoor/crossBuildingRouteFlow.ts
@@ -1,6 +1,8 @@
 import type {
   BuildCrossBuildingRouteFlowInput,
   BuildCrossBuildingRouteFlowResult,
+  CrossBuildingRoomEndpoint,
+  IndoorTransferPoint,
 } from '../../types/CrossBuildingRoute';
 import { findIndoorPath } from './indoorPathFinding';
 import { getIndoorGraph } from './indoorGraphs';
@@ -40,107 +42,162 @@ const canReachTransferPoint = ({
   return Boolean(path && path.length > 0);
 };
 
+const validateTransferPoint = ({
+  room,
+  buildingKey,
+  buildingName,
+  transferPoint,
+  indoorTravelMode,
+  direction,
+}: {
+  room: CrossBuildingRoomEndpoint | null | undefined;
+  buildingKey: IndoorBuildingKey;
+  buildingName: string;
+  transferPoint: IndoorTransferPoint | null;
+  indoorTravelMode: BuildCrossBuildingRouteFlowInput['indoorTravelMode'];
+  direction: 'origin' | 'destination';
+}): { ok: true } | { ok: false; message: string } => {
+  if (!room) return { ok: true };
+
+  if (!transferPoint) {
+    return {
+      ok: false,
+      message: `No building exit is configured yet for ${getBuildingLabel(buildingName, buildingKey)}.`,
+    };
+  }
+
+  if (indoorTravelMode === 'disability' && !transferPoint.accessible) {
+    return {
+      ok: false,
+      message: `${getBuildingLabel(buildingName, buildingKey)} does not have an accessible transfer point configured yet.`,
+    };
+  }
+
+  const canReach =
+    direction === 'origin'
+      ? canReachTransferPoint({
+          buildingKey,
+          startId: room.id,
+          endId: transferPoint.accessNodeId,
+          indoorTravelMode,
+        })
+      : canReachTransferPoint({
+          buildingKey,
+          startId: transferPoint.accessNodeId,
+          endId: room.id,
+          indoorTravelMode,
+        });
+
+  if (canReach) return { ok: true };
+
+  return {
+    ok: false,
+    message:
+      direction === 'origin'
+        ? `No indoor route could be found from ${room.label} to the exit for ${getBuildingLabel(buildingName, buildingKey)}.`
+        : `No indoor route could be found from the entrance of ${getBuildingLabel(buildingName, buildingKey)} to ${room.label}.`,
+  };
+};
+
 export const buildCrossBuildingRouteFlow = ({
   startRoom,
+  startBuilding,
   destinationRoom,
+  destinationBuilding,
   buildings,
   indoorTravelMode,
   outdoorMode,
 }: BuildCrossBuildingRouteFlowInput): BuildCrossBuildingRouteFlowResult => {
-  if (startRoom.buildingKey === destinationRoom.buildingKey) {
+  if (!startRoom && !destinationRoom) {
     return {
       ok: false,
-      message: 'Choose two rooms in different buildings to start a staged cross-building route.',
+      message: 'Choose at least one room to start a staged hybrid route.',
     };
   }
 
-  const originBuilding = resolveBuildingShape(buildings, startRoom.buildingKey);
-  if (!originBuilding) {
+  const originBuildingKey =
+    startRoom?.buildingKey ?? getIndoorBuildingKeyFromShape(startBuilding ?? null);
+  const destinationBuildingKey =
+    destinationRoom?.buildingKey ?? getIndoorBuildingKeyFromShape(destinationBuilding ?? null);
+
+  if (originBuildingKey && destinationBuildingKey && originBuildingKey === destinationBuildingKey) {
+    return {
+      ok: false,
+      message:
+        startRoom && destinationRoom
+          ? 'Choose two rooms in different buildings to start a staged cross-building route.'
+          : 'Choose endpoints in different buildings to start a staged hybrid route.',
+    };
+  }
+
+  const originBuilding =
+    startRoom && originBuildingKey
+      ? resolveBuildingShape(buildings, originBuildingKey)
+      : (startBuilding ?? null);
+  if (startRoom && (!originBuilding || !originBuildingKey)) {
     return {
       ok: false,
       message: `Building details are unavailable for ${startRoom.buildingKey}.`,
     };
   }
 
-  const destinationBuilding = resolveBuildingShape(buildings, destinationRoom.buildingKey);
-  if (!destinationBuilding) {
+  const resolvedDestinationBuilding =
+    destinationRoom && destinationBuildingKey
+      ? resolveBuildingShape(buildings, destinationBuildingKey)
+      : (destinationBuilding ?? null);
+  if (!resolvedDestinationBuilding) {
     return {
       ok: false,
-      message: `Building details are unavailable for ${destinationRoom.buildingKey}.`,
+      message: `Building details are unavailable for ${destinationRoom?.buildingKey ?? 'the selected destination'}.`,
     };
   }
 
-  const originTransferPoint = getIndoorTransferPoint(startRoom.buildingKey);
-  if (!originTransferPoint) {
-    return {
-      ok: false,
-      message: `No building exit is configured yet for ${getBuildingLabel(originBuilding.name, startRoom.buildingKey)}.`,
-    };
-  }
+  const originTransferPoint = startRoom ? getIndoorTransferPoint(startRoom.buildingKey) : null;
+  const destinationTransferPoint = destinationRoom
+    ? getIndoorTransferPoint(destinationRoom.buildingKey)
+    : null;
 
-  const destinationTransferPoint = getIndoorTransferPoint(destinationRoom.buildingKey);
-  if (!destinationTransferPoint) {
-    return {
-      ok: false,
-      message: `No building exit is configured yet for ${getBuildingLabel(destinationBuilding.name, destinationRoom.buildingKey)}.`,
-    };
-  }
-
-  if (indoorTravelMode === 'disability') {
-    if (!originTransferPoint.accessible) {
-      return {
-        ok: false,
-        message: `${getBuildingLabel(originBuilding.name, startRoom.buildingKey)} does not have an accessible transfer point configured yet.`,
-      };
-    }
-
-    if (!destinationTransferPoint.accessible) {
-      return {
-        ok: false,
-        message: `${getBuildingLabel(destinationBuilding.name, destinationRoom.buildingKey)} does not have an accessible transfer point configured yet.`,
-      };
+  if (startRoom && originBuilding && originBuildingKey) {
+    const originValidation = validateTransferPoint({
+      room: startRoom,
+      buildingKey: originBuildingKey,
+      buildingName: originBuilding.name,
+      transferPoint: originTransferPoint,
+      indoorTravelMode,
+      direction: 'origin',
+    });
+    if (!originValidation.ok) {
+      return originValidation;
     }
   }
 
-  if (
-    !canReachTransferPoint({
-      buildingKey: startRoom.buildingKey,
-      startId: startRoom.id,
-      endId: originTransferPoint.accessNodeId,
+  if (destinationRoom && destinationBuildingKey) {
+    const destinationValidation = validateTransferPoint({
+      room: destinationRoom,
+      buildingKey: destinationBuildingKey,
+      buildingName: resolvedDestinationBuilding.name,
+      transferPoint: destinationTransferPoint,
       indoorTravelMode,
-    })
-  ) {
-    return {
-      ok: false,
-      message: `No indoor route could be found from ${startRoom.label} to the exit for ${getBuildingLabel(originBuilding.name, startRoom.buildingKey)}.`,
-    };
+      direction: 'destination',
+    });
+    if (!destinationValidation.ok) {
+      return destinationValidation;
+    }
   }
 
-  if (
-    !canReachTransferPoint({
-      buildingKey: destinationRoom.buildingKey,
-      startId: destinationTransferPoint.accessNodeId,
-      endId: destinationRoom.id,
-      indoorTravelMode,
-    })
-  ) {
-    return {
-      ok: false,
-      message: `No indoor route could be found from the entrance of ${getBuildingLabel(destinationBuilding.name, destinationRoom.buildingKey)} to ${destinationRoom.label}.`,
-    };
-  }
+  const initialStage = startRoom ? 'origin_indoor' : 'outdoor';
 
   return {
     ok: true,
     flow: {
-      startRoomEndpoint: startRoom,
-      destinationRoomEndpoint: destinationRoom,
+      startRoomEndpoint: startRoom ?? null,
+      destinationRoomEndpoint: destinationRoom ?? null,
       originBuilding,
-      destinationBuilding,
+      destinationBuilding: resolvedDestinationBuilding,
       originTransferPoint,
       destinationTransferPoint,
       outdoorMode,
-      currentStage: 'origin_indoor',
+      currentStage: initialStage,
     },
   };
 };


### PR DESCRIPTION
## Summary
Implements `TASK-6.4` under `US-6.4` by unifying route selection around a single mixed SearchSheet that shows both buildings and rooms in the same search experience. This also unblocks hybrid route selection flows like outdoor-to-indoor, indoor-to-outdoor, and room/building mixed endpoints by extending the staged routing flow beyond room-to-room only.

## Changes
- Replaced the route-search variants with the mixed SearchSheet layout everywhere so route selection consistently shows both room and building results.
- Updated `BottomSheet` route selection state to support unified mixed endpoint picking for start and destination across outdoor, indoor, and hybrid flows.
- Extended staged cross-building routing to support `room -> building`, `building -> room`, `room -> room`, and outdoor/current-location -> room flows without regressing existing same-building indoor or building-to-building outdoor routes.
- Updated regression tests for SearchSheet, BottomSheet, and cross-building route flow behavior.

## How to Test
1. Open the app and try route selection from both the outdoor map and an indoor map.
2. Use the same SearchSheet to select mixed endpoints across these cases: building -> building, room -> building, building -> room, and room -> room in different buildings.
3. Confirm the SearchSheet always shows both room and building results, and that the app enters the correct outdoor/indoor staged route flow for each case without blocking outdoor-to-indoor navigation.

## Notes
- This PR keeps the existing mixed SearchSheet design as the canonical route-search experience and removes the need to maintain separate room-only/building-only route search behavior.
- The main change is in route selection and staged flow orchestration; no major visual redesign beyond standardizing on the existing mixed SearchSheet layout.
- Verified locally with focused Jest coverage and TypeScript checks.


## Screenshots
![task6 4](https://github.com/user-attachments/assets/52483d35-5f89-4fc6-861c-babc9b11869c)

## Checklist
- [x] Builds/runs locally (or via Expo Go / emulator)
- [x] Meets acceptance criteria for the linked task/user story
- [ ] Lint/format checks pass (if configured)
- [x] Tests added/updated (if applicable)
- [ ] Screenshots included (for UI changes)
- [x] Ready to squash & merge
