### PR TITLE
BUG-4.1.4: Unable to reopen the calendar through calendar button in the indoor controls

### DIFF
--- a/mobile/__test__/App.test.tsx
+++ b/mobile/__test__/App.test.tsx
@@ -9,6 +9,7 @@ const mockInitializeClarityAsync = jest.fn(async () => {});
 const mockCloseCalendarSlider = jest.fn();
 const mockBottomSheetOpen = jest.fn();
 const mockOpenCalendarEventsSlider = jest.fn();
+const mockOpenIndoorDirections = jest.fn();
 const mockGetStoredGoogleCalendarSessionState = jest.fn(
   async (): Promise<any> => ({
     status: 'not_connected',
@@ -34,13 +35,14 @@ jest.mock('../src/components/BottomSheet', () => {
   const { TouchableOpacity, View, Text } = require('react-native');
 
   const MockBottomSheet = React.forwardRef(function MockBottomSheet(
-    { revealSearchBar, onExitSearch, onPrevPathFloor, onNextPathFloor }: any,
+    { revealSearchBar, onExitSearch, onPrevPathFloor, onNextPathFloor, enterIndoorView }: any,
     ref: any,
   ) {
     React.useImperativeHandle(ref, () => ({
       open: mockBottomSheetOpen,
       closeCalendarSlider: mockCloseCalendarSlider,
       openCalendarEventsSlider: mockOpenCalendarEventsSlider,
+      openIndoorDirections: mockOpenIndoorDirections,
     }));
     return (
       <View testID="bottom-sheet">
@@ -55,6 +57,9 @@ jest.mock('../src/components/BottomSheet', () => {
         </TouchableOpacity>
         <TouchableOpacity testID="trigger-next-floor" onPress={onNextPathFloor}>
           <Text>Next Floor</Text>
+        </TouchableOpacity>
+        <TouchableOpacity testID="trigger-enter-indoor" onPress={enterIndoorView}>
+          <Text>Enter Indoor</Text>
         </TouchableOpacity>
       </View>
     );
@@ -164,6 +169,7 @@ describe('App', () => {
     mockCloseCalendarSlider.mockClear();
     mockBottomSheetOpen.mockClear();
     mockOpenCalendarEventsSlider.mockClear();
+    mockOpenIndoorDirections.mockClear();
     mockGetStoredGoogleCalendarSessionState.mockResolvedValue({
       status: 'not_connected',
       session: null,
@@ -327,6 +333,19 @@ describe('App', () => {
     fireEvent.press(getByTestId('open-calendar-shortcut'));
 
     await waitFor(() => expect(queryByTestId('search-bar')).toBeNull());
+  });
+
+  test('calendar shortcut reopens the search sheet instead of indoor directions while indoor', async () => {
+    const { getByTestId, queryByTestId } = render(<App />);
+
+    fireEvent.press(getByTestId('trigger-enter-indoor'));
+    fireEvent.press(getByTestId('open-calendar-shortcut'));
+
+    await waitFor(() => {
+      expect(mockBottomSheetOpen).toHaveBeenCalledWith(1);
+      expect(mockOpenIndoorDirections).not.toHaveBeenCalled();
+      expect(queryByTestId('search-bar')).toBeNull();
+    });
   });
 
   test('fonts not loaded returns null and renders nothing', () => {

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -79,8 +79,14 @@ const App = () => {
     }
   }, [isIndoor]);
 
+  const openCalendarSheet = useCallback(() => {
+    setSheetMode('search');
+    setSheetOpen(true);
+    bottomSheetRef.current?.open(1);
+  }, []);
+
   const handleOpenCalendar = useCallback(async () => {
-    openSearchBuilding();
+    openCalendarSheet();
 
     const sessionState = await getStoredGoogleCalendarSessionState();
     if (sessionState.status !== 'connected' || !sessionState.session) {
@@ -90,7 +96,7 @@ const App = () => {
     requestAnimationFrame(() => {
       bottomSheetRef.current?.openCalendarEventsSlider();
     });
-  }, [openSearchBuilding]);
+  }, [openCalendarSheet]);
 
   const openCalendarFromMap = useCallback(() => {
     handleOpenCalendar().catch((error) => {


### PR DESCRIPTION
## Summary
Implements `BUG-4.1.4` by fixing the indoor calendar button flow so reopening the calendar/search view from indoor controls opens the SearchSheet instead of incorrectly reopening indoor directions. This restores the expected calendar access after a prior indoor search.

## Changes
- Updated the app-level calendar shortcut flow to always open the bottom sheet in search mode before loading calendar content.
- Prevented the indoor calendar button from reusing the indoor-directions opener when the user is already inside an indoor map.
- Added a regression test covering the indoor calendar reopen case to ensure it opens the search/calendar view instead of indoor directions.

## How to Test
1. Enter an indoor map and perform a room search from the bottom sheet/search flow.
2. Close the bottom sheet, then press the calendar button in the indoor controls.
3. Confirm the bottom sheet reopens the search/calendar view and does not reopen the indoor directions panel.

## Notes
- This fix is scoped to the indoor calendar reopen flow and does not change the calendar event loading behavior itself.
- The issue was in the app-level bottom sheet control flow, not in the indoor controls component UI.

## Screenshots
![bug4 1 4](https://github.com/user-attachments/assets/864a152a-3fb8-4520-ab2d-a7bc17b259d6)


## Checklist
- [x] Builds/runs locally (or via Expo Go / emulator)
- [x] Meets acceptance criteria for the linked task/user story
- [x] Lint/format checks pass (if configured)
- [x] Tests added/updated (if applicable)
- [x] Screenshots included (for UI changes)
- [x] Ready to squash & merge
