### PR TITLE
BUG-4.1.2: Indoor directions bottom sheet stays visible after exiting back to outdoor map

### DIFF
--- a/mobile/__test__/App.test.tsx
+++ b/mobile/__test__/App.test.tsx
@@ -6,9 +6,11 @@ import App from '../src/App';
 
 const mockUseFonts = jest.fn(() => [true]);
 const mockInitializeClarityAsync = jest.fn(async () => {});
+const mockBottomSheetClose = jest.fn();
 const mockCloseCalendarSlider = jest.fn();
 const mockBottomSheetOpen = jest.fn();
 const mockOpenCalendarEventsSlider = jest.fn();
+const mockOpenIndoorDirections = jest.fn();
 const mockGetStoredGoogleCalendarSessionState = jest.fn(
   async (): Promise<any> => ({
     status: 'not_connected',
@@ -34,13 +36,15 @@ jest.mock('../src/components/BottomSheet', () => {
   const { TouchableOpacity, View, Text } = require('react-native');
 
   const MockBottomSheet = React.forwardRef(function MockBottomSheet(
-    { revealSearchBar, onExitSearch, onPrevPathFloor, onNextPathFloor }: any,
+    { revealSearchBar, onExitSearch, onPrevPathFloor, onNextPathFloor, enterIndoorView }: any,
     ref: any,
   ) {
     React.useImperativeHandle(ref, () => ({
       open: mockBottomSheetOpen,
+      close: mockBottomSheetClose,
       closeCalendarSlider: mockCloseCalendarSlider,
       openCalendarEventsSlider: mockOpenCalendarEventsSlider,
+      openIndoorDirections: mockOpenIndoorDirections,
     }));
     return (
       <View testID="bottom-sheet">
@@ -55,6 +59,9 @@ jest.mock('../src/components/BottomSheet', () => {
         </TouchableOpacity>
         <TouchableOpacity testID="trigger-next-floor" onPress={onNextPathFloor}>
           <Text>Next Floor</Text>
+        </TouchableOpacity>
+        <TouchableOpacity testID="trigger-enter-indoor" onPress={enterIndoorView}>
+          <Text>Enter Indoor</Text>
         </TouchableOpacity>
       </View>
     );
@@ -161,9 +168,11 @@ describe('App', () => {
   beforeEach(() => {
     mockUseFonts.mockReturnValue([true]);
     mockInitializeClarityAsync.mockClear();
+    mockBottomSheetClose.mockClear();
     mockCloseCalendarSlider.mockClear();
     mockBottomSheetOpen.mockClear();
     mockOpenCalendarEventsSlider.mockClear();
+    mockOpenIndoorDirections.mockClear();
     mockGetStoredGoogleCalendarSessionState.mockResolvedValue({
       status: 'not_connected',
       session: null,
@@ -354,6 +363,21 @@ describe('App', () => {
   test('exitIndoorView resets isIndoor to false without throwing', () => {
     const { getByTestId } = render(<App />);
     expect(() => fireEvent.press(getByTestId('trigger-exit-indoor'))).not.toThrow();
+  });
+
+  test('exiting indoor view closes the bottom sheet and restores the outdoor search bar', () => {
+    const { getByTestId, queryByTestId } = render(<App />);
+
+    fireEvent.press(getByTestId('trigger-enter-indoor'));
+    fireEvent.press(getByTestId('open-search'));
+
+    expect(mockOpenIndoorDirections).toHaveBeenCalledTimes(1);
+    expect(queryByTestId('search-bar')).toBeNull();
+
+    fireEvent.press(getByTestId('trigger-exit-indoor'));
+
+    expect(mockBottomSheetClose).toHaveBeenCalledTimes(1);
+    expect(getByTestId('search-bar')).toBeTruthy();
   });
 
   test('hideAppSearchBar hides the AppSearchBar', () => {

--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -140,6 +140,9 @@ const App = () => {
   }, []);
 
   const handleExitIndoorView = useCallback(() => {
+    bottomSheetRef.current?.close();
+    setSheetMode('detail');
+    setSheetOpen(false);
     setIsIndoor(false);
   }, []);
 


### PR DESCRIPTION
## Summary
Implements `BUG-4.1.2` by closing the shared bottom sheet when exiting indoor mode so indoor directions UI does not remain visible over the outdoor map. This restores the expected transition back to the outdoor map after leaving indoor navigation.

## Changes
- Updated the indoor exit flow in `App.tsx` to close the shared bottom sheet when returning to the outdoor map.
- Reset the app-level sheet state on indoor exit so the UI returns to the normal outdoor detail/search behavior.
- Added a regression test covering the case where indoor directions are open and the user exits back to the outdoor map.

## How to Test
1. Enter a building with indoor maps and start indoor directions between two rooms.
2. Exit indoor mode using the indoor controls.
3. Confirm the app returns to the outdoor map with the indoor directions bottom sheet dismissed.

## Notes
- This fix is scoped to the indoor-exit transition and does not change indoor routing logic itself.
- The issue was caused by app-level bottom sheet state not being cleared when indoor mode was dismissed.

## Screenshots
![bug4 1 2](https://github.com/user-attachments/assets/546e124b-759c-4779-9d9c-c4037dd32a55)

## Checklist
- [x] Builds/runs locally (or via Expo Go / emulator)
- [x] Meets acceptance criteria for the linked task/user story
- [x] Lint/format checks pass (if configured)
- [x] Tests added/updated (if applicable)
- [x] Screenshots included (for UI changes)
- [x] Ready to squash & merge


