### PR TITLE
TASK-3.4.5: Refactor calendar GO hybrid routing flow

### DIFF
--- a/mobile/__test__/BottomSheet.test.tsx
+++ b/mobile/__test__/BottomSheet.test.tsx
@@ -697,9 +697,7 @@ describe('BottomSheet', () => {
     jest.useRealTimers();
     delete process.env.EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_WEEKDAY;
     delete process.env.EXPO_PUBLIC_SHUTTLE_DEBUG_FORCE_PLANNING_TIME;
-    mockGetManualStartReasonMessage.mockReturnValue(
-      'Location permission required—please select your starting building manually',
-    );
+    mockGetManualStartReasonMessage.mockReturnValue('');
     mockResolveCalendarRouteLocation.mockResolvedValue({
       type: 'success',
       value: {
@@ -3229,12 +3227,111 @@ describe('BottomSheet', () => {
     expect(queryByTestId('calendar-selection-slider')).toBeNull();
   });
 
+  test('calendar GO with a resolved room inside a building prompts for exact start room first', async () => {
+    crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow.mockReturnValueOnce({
+      ok: true,
+      flow: {
+        startRoomEndpoint: mockSameBuildingRoom,
+        destinationRoomEndpoint: mockOtherBuildingRoom,
+        originBuilding: mockSameBuildingSearchResult,
+        destinationBuilding: mockOtherBuildingSearchResult,
+        originTransferPoint: {
+          buildingKey: 'H',
+          campus: 'SGW',
+          accessNodeId: 'H1_F1_building_entry_exit_7',
+          outdoorCoords: { latitude: 45.497092, longitude: -73.5788 },
+          accessible: true,
+        },
+        destinationTransferPoint: {
+          buildingKey: 'VE',
+          campus: 'LOYOLA',
+          accessNodeId: 'VE_F1_building_entry_exit_6',
+          outdoorCoords: { latitude: 45.459026, longitude: -73.638606 },
+          accessible: true,
+        },
+        outdoorMode: 'walking',
+        currentStage: 'origin_indoor',
+      },
+    });
+
+    mockResolveCalendarRouteLocation.mockResolvedValueOnce({
+      type: 'success',
+      value: {
+        destinationBuilding: mockOtherBuildingSearchResult,
+        destinationRoomEndpoint: mockOtherBuildingRoom,
+        startPoint: {
+          type: 'automatic',
+          coordinates: { latitude: 45.4971, longitude: -73.5791 },
+          building: mockSameBuildingSearchResult,
+        },
+        normalizedEventLocation: 'VE 1 615',
+        rawEventLocation: 'VE-1.615',
+      },
+    });
+
+    const SearchModeHarness = () => {
+      const [mode, setMode] = React.useState<'search' | 'detail'>('search');
+      const [selectedBuilding, setSelectedBuilding] = React.useState<BuildingShape | null>(
+        mockSameBuildingSearchResult,
+      );
+      return (
+        <BottomSlider
+          {...defaultProps}
+          ref={createRef()}
+          mode={mode}
+          selectedBuilding={selectedBuilding}
+          passSelectedBuilding={setSelectedBuilding}
+          onExitSearch={() => setMode('detail')}
+        />
+      );
+    };
+
+    const { getByTestId } = render(<SearchModeHarness />);
+    fireEvent.press(getByTestId('trigger-calendar-go-with-event'));
+
+    await waitFor(() => {
+      expect(getByTestId('hybrid-directions-details')).toBeTruthy();
+      expect(getByTestId('hybrid-start-label').props.children).toBe('Hall Building');
+      expect(getByTestId('hybrid-destination-label').props.children).toBe('VE-1.615');
+      expect(getByTestId('hybrid-summary-message').props.children).toBe(
+        'Choose your current room as the start point to continue.',
+      );
+    });
+
+    expect(crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow).not.toHaveBeenCalled();
+
+    await pressAndFlush(getByTestId('hybrid-press-start'));
+    await pressAndFlush(getByTestId('select-room-in-search'));
+    await pressAndFlush(getByTestId('hybrid-go-button'));
+
+    expect(crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destinationRoom: mockOtherBuildingRoom,
+        outdoorMode: 'walking',
+        startRoom: expect.objectContaining({
+          id: mockSameBuildingRoom.id,
+          label: mockSameBuildingRoom.label,
+          buildingKey: 'H',
+        }),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('indoor-navigation-details')).toBeTruthy();
+      expect(getByTestId('indoor-navigation-start-room').props.children).toBe('H-811');
+      expect(getByTestId('indoor-navigation-destination-room').props.children).toBe('H Exit');
+      expect(defaultProps.enterIndoorView).toHaveBeenCalled();
+      expect(defaultProps.onEnterBuilding).toHaveBeenCalledWith(mockSameBuildingSearchResult);
+    });
+  });
+
   // here
   test('handleUpcomingClassPress sets manual start when startPoint type is manual', async () => {
     mockResolveCalendarRouteLocation.mockResolvedValueOnce({
       type: 'success',
       value: {
         destinationBuilding: mockBuildings[1],
+        destinationRoomEndpoint: null,
         startPoint: { type: 'manual', reason: 'location_permission_denied' },
         normalizedEventLocation: 'HALL BUILDING 435',
         rawEventLocation: 'Hall Building 435',

--- a/mobile/__test__/BottomSheet.test.tsx
+++ b/mobile/__test__/BottomSheet.test.tsx
@@ -3366,6 +3366,181 @@ describe('BottomSheet', () => {
     });
   });
 
+  test('calendar GO with a room destination and manual start opens hybrid directions without building a staged flow', async () => {
+    mockResolveCalendarRouteLocation.mockResolvedValueOnce({
+      type: 'success',
+      value: {
+        destinationBuilding: mockOtherBuildingSearchResult,
+        destinationRoomEndpoint: mockOtherBuildingRoom,
+        startPoint: { type: 'manual', reason: 'outside_campus' },
+        normalizedEventLocation: 'VE 1 615',
+        rawEventLocation: 'VE-1.615',
+      },
+    });
+
+    const SearchModeHarness = () => {
+      const [mode, setMode] = React.useState<'search' | 'detail'>('search');
+      const [selectedBuilding, setSelectedBuilding] = React.useState<BuildingShape | null>(
+        mockSameBuildingSearchResult,
+      );
+
+      return (
+        <BottomSlider
+          {...defaultProps}
+          ref={createRef()}
+          mode={mode}
+          selectedBuilding={selectedBuilding}
+          passSelectedBuilding={setSelectedBuilding}
+          onExitSearch={() => setMode('detail')}
+        />
+      );
+    };
+
+    const { getByTestId } = render(<SearchModeHarness />);
+    fireEvent.press(getByTestId('trigger-calendar-go-with-event'));
+
+    await waitFor(() => {
+      expect(getByTestId('hybrid-directions-details')).toBeTruthy();
+      expect(getByTestId('hybrid-start-label').props.children).toBe('none');
+      expect(getByTestId('hybrid-destination-label').props.children).toBe('VE-1.615');
+    });
+
+    expect(mockGetManualStartReasonMessage).toHaveBeenCalledWith('outside_campus');
+    expect(crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow).not.toHaveBeenCalled();
+  });
+
+  test('calendar GO with a room destination surfaces staged-flow build errors when start is outdoor', async () => {
+    crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow.mockReturnValueOnce({
+      ok: false,
+      message: 'No transfer route available for this class.',
+    });
+    mockResolveCalendarRouteLocation.mockResolvedValueOnce({
+      type: 'success',
+      value: {
+        destinationBuilding: mockOtherBuildingSearchResult,
+        destinationRoomEndpoint: mockOtherBuildingRoom,
+        startPoint: {
+          type: 'automatic',
+          coordinates: { latitude: 45.4972, longitude: -73.5792 },
+          building: null,
+        },
+        normalizedEventLocation: 'VE 1 615',
+        rawEventLocation: 'VE-1.615',
+      },
+    });
+
+    const SearchModeHarness = () => {
+      const [mode, setMode] = React.useState<'search' | 'detail'>('search');
+      const [selectedBuilding, setSelectedBuilding] = React.useState<BuildingShape | null>(
+        mockSameBuildingSearchResult,
+      );
+
+      return (
+        <BottomSlider
+          {...defaultProps}
+          ref={createRef()}
+          mode={mode}
+          selectedBuilding={selectedBuilding}
+          passSelectedBuilding={setSelectedBuilding}
+          onExitSearch={() => setMode('detail')}
+        />
+      );
+    };
+
+    const { getByTestId } = render(<SearchModeHarness />);
+    fireEvent.press(getByTestId('trigger-calendar-go-with-event'));
+
+    await waitFor(() => {
+      expect(getByTestId('hybrid-directions-details')).toBeTruthy();
+      expect(getByTestId('hybrid-start-label').props.children).toBe('My Location');
+      expect(getByTestId('hybrid-error-message').props.children).toBe(
+        'No transfer route available for this class.',
+      );
+    });
+
+    expect(crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startRoom: null,
+        startBuilding: null,
+        destinationRoom: mockOtherBuildingRoom,
+        outdoorMode: 'walking',
+      }),
+    );
+  });
+
+  test('calendar GO with a room destination and outdoor start enters staged outdoor directions directly', async () => {
+    crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow.mockReturnValueOnce({
+      ok: true,
+      flow: {
+        startRoomEndpoint: null,
+        destinationRoomEndpoint: mockOtherBuildingRoom,
+        originBuilding: null,
+        destinationBuilding: mockOtherBuildingSearchResult,
+        originTransferPoint: null,
+        destinationTransferPoint: {
+          buildingKey: 'VE',
+          campus: 'LOYOLA',
+          accessNodeId: 'VE_F1_building_entry_exit_6',
+          outdoorCoords: { latitude: 45.459026, longitude: -73.638606 },
+          accessible: true,
+        },
+        outdoorMode: 'walking',
+        currentStage: 'outdoor',
+      },
+    });
+    mockResolveCalendarRouteLocation.mockResolvedValueOnce({
+      type: 'success',
+      value: {
+        destinationBuilding: mockOtherBuildingSearchResult,
+        destinationRoomEndpoint: mockOtherBuildingRoom,
+        startPoint: {
+          type: 'automatic',
+          coordinates: { latitude: 45.4972, longitude: -73.5792 },
+          building: null,
+        },
+        normalizedEventLocation: 'VE 1 615',
+        rawEventLocation: 'VE-1.615',
+      },
+    });
+
+    const SearchModeHarness = () => {
+      const [mode, setMode] = React.useState<'search' | 'detail'>('search');
+      const [selectedBuilding, setSelectedBuilding] = React.useState<BuildingShape | null>(
+        mockSameBuildingSearchResult,
+      );
+
+      return (
+        <BottomSlider
+          {...defaultProps}
+          ref={createRef()}
+          mode={mode}
+          selectedBuilding={selectedBuilding}
+          passSelectedBuilding={setSelectedBuilding}
+          onExitSearch={() => setMode('detail')}
+        />
+      );
+    };
+
+    const { getByTestId, queryByTestId } = render(<SearchModeHarness />);
+    fireEvent.press(getByTestId('trigger-calendar-go-with-event'));
+
+    await waitFor(() => {
+      expect(getByTestId('direction-details')).toBeTruthy();
+      expect(getByTestId('route-stage-action-button')).toBeTruthy();
+      expect(queryByTestId('hybrid-directions-details')).toBeNull();
+    });
+
+    expect(defaultProps.onShowOutdoorMap).toHaveBeenCalledTimes(1);
+    expect(crossBuildingRouteFlowMock.buildCrossBuildingRouteFlow).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startRoom: null,
+        startBuilding: null,
+        destinationRoom: mockOtherBuildingRoom,
+        outdoorMode: 'walking',
+      }),
+    );
+  });
+
   test('openIndoorDirections and openIndoorNavigation both snap to expanded', async () => {
     const ref = createRef<BottomSliderHandle>();
     render(<BottomSlider {...defaultProps} ref={ref} selectedBuilding={null} />);

--- a/mobile/__test__/calendarRouteLocation.test.ts
+++ b/mobile/__test__/calendarRouteLocation.test.ts
@@ -69,6 +69,7 @@ describe('calendarRouteLocation', () => {
     expect(result.type).toBe('success');
     if (result.type !== 'success') return;
     expect(result.value.destinationBuilding.id).toBe('hall');
+    expect(result.value.destinationRoomEndpoint?.label).toBe('H-110');
     expect(result.value.normalizedEventLocation).toBe('SGW H 110');
     expect(result.value.startPoint).toEqual({
       type: 'automatic',
@@ -90,6 +91,7 @@ describe('calendarRouteLocation', () => {
     if (result.type !== 'success') return;
     expect(result.value.destinationBuilding.id).toBe('hall');
     expect(result.value.destinationBuilding.name).toBe('Henry F. Hall Building');
+    expect(result.value.destinationRoomEndpoint).toBeNull();
   });
 
   test('resolves short-code location MB S1.150 to MB building', async () => {
@@ -105,6 +107,22 @@ describe('calendarRouteLocation', () => {
     if (result.type !== 'success') return;
     expect(result.value.destinationBuilding.id).toBe('mb');
     expect(result.value.destinationBuilding.shortCode).toBe('MB');
+    expect(result.value.destinationRoomEndpoint).toBeNull();
+  });
+
+  test('resolves MB S2 210 to the mapped MB room endpoint', async () => {
+    locationUtilsMock.getCurrentLocationResult.mockResolvedValueOnce({
+      type: 'success',
+      coords: { latitude: 45.5, longitude: -73.57 },
+    });
+    buildingsRepositoryMock.findBuildingAt.mockReturnValueOnce(hallBuilding);
+
+    const result = await resolveCalendarRouteLocation('MB S2 210');
+
+    expect(result.type).toBe('success');
+    if (result.type !== 'success') return;
+    expect(result.value.destinationBuilding.id).toBe('mb');
+    expect(result.value.destinationRoomEndpoint?.label).toBe('MB-S2.210');
   });
 
   test('resolves compact room location H435 to Hall building', async () => {
@@ -133,6 +151,7 @@ describe('calendarRouteLocation', () => {
     expect(result.type).toBe('success');
     if (result.type !== 'success') return;
     expect(result.value.destinationBuilding.id).toBe('hall');
+    expect(result.value.destinationRoomEndpoint?.label).toBe('H-110');
     expect(result.value.startPoint).toEqual({
       type: 'manual',
       reason: 'permission_denied',
@@ -168,15 +187,11 @@ describe('calendarRouteLocation', () => {
   });
 
   test('maps manual fallback reasons to user-friendly messages', () => {
-    expect(getManualStartReasonMessage('permission_denied')).toBe(
-      'Location permission required—please select your starting building manually',
-    );
+    expect(getManualStartReasonMessage('permission_denied')).toBe('');
     expect(getManualStartReasonMessage('location_unavailable')).toBe(
       'Could not generate route—try again',
     );
-    expect(getManualStartReasonMessage('outside_campus')).toBe(
-      'Location permission required—please select your starting building manually',
-    );
+    expect(getManualStartReasonMessage('outside_campus')).toBe('');
   });
 
   test('resolves a supported event destination without requiring async start-point lookup', () => {
@@ -185,6 +200,7 @@ describe('calendarRouteLocation', () => {
     expect(result.type).toBe('success');
     if (result.type !== 'success') return;
     expect(result.value.destinationBuilding.id).toBe('mb');
+    expect(result.value.destinationRoomEndpoint).toBeNull();
     expect(result.value.normalizedEventLocation).toBe('MB S1 150');
     expect(result.value.rawEventLocation).toBe('MB S1.150');
   });

--- a/mobile/maestro/at_3_4_5.yaml
+++ b/mobile/maestro/at_3_4_5.yaml
@@ -1,0 +1,10 @@
+appId: com.anonymous.mobile
+---
+- tapOn: Get to...
+- assertVisible: MB-1.294
+- tapOn: GO
+- tapOn: GO
+- tapOn: Enter Building
+- swipe:
+    start: '50%, 55%'
+    end: '50%, 85%'

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -55,9 +55,13 @@ import { IndoorRoutePlannerMode } from '../types/SheetMode';
 import type { SearchMode } from '../types/SearchMode';
 import type { OutdoorPoi, PoiCategorySelection, PoiRangeKm } from '../types/Poi';
 import HybridDirectionsDetails from './HybridDirectionsDetails';
-import { getIndoorBuildingKeyFromShape } from '../utils/indoor/buildingKeys';
+import {
+  getIndoorBuildingCampus,
+  getIndoorBuildingKeyFromShape,
+} from '../utils/indoor/buildingKeys';
 import { getIndoorTransferPoint } from '../utils/indoor/indoorTransferPoints';
 import { buildCrossBuildingRouteFlow } from '../utils/indoor/crossBuildingRouteFlow';
+import { getIndoorGraph } from '../utils/indoor/indoorGraphs';
 import {
   getCrossBuildingRouteFlowPresentation,
   useCrossBuildingRouteFlow,
@@ -286,6 +290,32 @@ const getEndpointLabel = (endpoint: MixedEndpoint | null): string | null => {
 
 const getWaypointBuildingLabel = (building: Pick<BuildingShape, 'shortCode' | 'name'>) =>
   building.shortCode ?? building.name;
+
+const getTransferRoomEndpoint = ({
+  building,
+  labelSuffix,
+}: {
+  building: BuildingShape;
+  labelSuffix: 'Entrance' | 'Exit';
+}): RoomNode | null => {
+  const buildingKey = getIndoorBuildingKeyFromShape(building);
+  if (!buildingKey) return null;
+
+  const transferPoint = getIndoorTransferPoint(buildingKey);
+  if (!transferPoint) return null;
+
+  const graph = getIndoorGraph(buildingKey);
+  const transferNode = graph?.nodes.find((node) => node.id === transferPoint.accessNodeId);
+
+  return {
+    id: transferPoint.accessNodeId,
+    label: `${getWaypointBuildingLabel(building)} ${labelSuffix}`,
+    buildingId: transferNode?.buildingId ?? buildingKey,
+    buildingKey,
+    campus: getIndoorBuildingCampus(buildingKey),
+    floor: transferNode?.floor ?? 1,
+  };
+};
 
 const getEndpointBuildingKey = (endpoint: MixedEndpoint | null): string | null => {
   if (!endpoint) return null;
@@ -1262,6 +1292,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
     const [indoorTravelMode, setIndoorTravelMode] = useState<'walking' | 'disability'>('walking');
     const [hybridOutdoorTravelMode, setHybridOutdoorTravelMode] =
       useState<RoutePlannerMode>('walking');
+    const [requiresIndoorStartRoomSelection, setRequiresIndoorStartRoomSelection] = useState(false);
     const {
       hasDirectionsStageAction,
       indoorNavigationBuilding,
@@ -1308,6 +1339,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       setStartLocationSnapshot(null);
       setRouteStartSource('current');
       setHybridOutdoorTravelMode('walking');
+      setRequiresIndoorStartRoomSelection(false);
       resetRouteState();
 
       onIndoorRouteChange?.(null, null);
@@ -1501,6 +1533,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
     const resetWalkingRouteFlow = useCallback(() => {
       clearCrossBuildingRouteFlowState();
       setHybridOutdoorTravelMode('walking');
+      setRequiresIndoorStartRoomSelection(false);
       setTravelMode('walking');
     }, [clearCrossBuildingRouteFlowState]);
 
@@ -1550,6 +1583,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
           setStartRoom(room.label);
           setStartBuilding(null);
           setStartEndpoint(nextEndpoint);
+          setRequiresIndoorStartRoomSelection(false);
         } else {
           if (isSelectingDestinationFromCurrent) {
             resetWalkingRouteFlow();
@@ -1721,6 +1755,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       setStartRoom(null);
       setDestinationRoom(null);
       setHybridOutdoorTravelMode('walking');
+      setRequiresIndoorStartRoomSelection(false);
       resetRouteState();
       onIndoorRouteChange?.(null, null);
       passSelectedBuilding(null);
@@ -1760,42 +1795,191 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
             return resolved.message;
           }
 
-          const { destinationBuilding: resolvedDestinationBuilding, startPoint } = resolved.value;
+          const {
+            destinationBuilding: resolvedDestinationBuilding,
+            destinationRoomEndpoint: resolvedDestinationRoomEndpoint,
+            startPoint,
+          } = resolved.value;
+
           passSelectedBuilding(resolvedDestinationBuilding);
-          setDestinationBuilding(resolvedDestinationBuilding);
-          setDestinationPoi(null);
-          setDestinationLocationSnapshot(null);
-          setDestinationEndpoint({ kind: 'building', building: resolvedDestinationBuilding });
-          setStartEndpoint(null);
-          setStartRoom(null);
-          setDestinationRoom(null);
-          onIndoorRouteChange?.(null, null);
-          setTravelMode('walking');
           setCalendarSliderMode(null);
           setSearchFor(null);
           onExitSearch();
-          setActiveView('directions');
+          setDestinationPoi(null);
+          setDestinationLocationSnapshot(null);
+          setTravelMode('walking');
+          setHybridOutdoorTravelMode('walking');
+          setRouteErrorMessage(null);
+          setHybridRouteErrorMessage(null);
+          setRequiresIndoorStartRoomSelection(false);
 
-          if (startPoint.type === 'automatic') {
-            setRouteStartSource('current');
-            setRouteErrorMessage(null);
-            // Calendar GO should always start from the user's live location coordinates.
-            setStartBuilding(null);
-            setStartLocationSnapshot(startPoint.coordinates);
-          } else {
-            setStartBuilding(null);
-            setStartLocationSnapshot(null);
-            setRouteStartSource('manual');
-            setRouteErrorMessage(getManualStartReasonMessage(startPoint.reason));
+          if (!resolvedDestinationRoomEndpoint) {
+            setDestinationBuilding(resolvedDestinationBuilding);
+            setDestinationEndpoint({ kind: 'building', building: resolvedDestinationBuilding });
+            setStartEndpoint(null);
+            setStartRoom(null);
+            setDestinationRoom(null);
+            onIndoorRouteChange?.(null, null);
+            setActiveView('directions');
+
+            if (startPoint.type === 'automatic') {
+              setRouteStartSource('current');
+              // Calendar GO should always start from the user's live location coordinates.
+              setStartBuilding(null);
+              setStartLocationSnapshot(startPoint.coordinates);
+            } else {
+              setStartBuilding(null);
+              setStartLocationSnapshot(null);
+              setRouteStartSource('manual');
+              setRouteErrorMessage(getManualStartReasonMessage(startPoint.reason));
+            }
+
+            snapToDirectionsPanel(DIRECTIONS_PANEL_SNAP_POINT);
+            return null;
           }
 
-          snapToDirectionsPanel(DIRECTIONS_PANEL_SNAP_POINT);
+          const resolvedDestinationRoom = resolvedDestinationRoomEndpoint as RoomNode;
+          setDestinationBuilding(resolvedDestinationBuilding);
+          setDestinationEndpoint({ kind: 'room', room: resolvedDestinationRoom });
+          setDestinationRoom(resolvedDestinationRoom.label);
+
+          if (startPoint.type !== 'automatic') {
+            setStartBuilding(null);
+            setStartLocationSnapshot(null);
+            setStartEndpoint(null);
+            setStartRoom(null);
+            setRouteStartSource('manual');
+            setHybridRouteErrorMessage(getManualStartReasonMessage(startPoint.reason));
+            setRequiresIndoorStartRoomSelection(false);
+            onIndoorRouteChange?.(null, null);
+            setActiveView('hybrid-directions');
+            requestAnimationFrame(() => {
+              sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
+            });
+            return null;
+          }
+
+          const automaticStartBuilding = startPoint.building;
+          const automaticStartBuildingKey = getIndoorBuildingKeyFromShape(automaticStartBuilding);
+          const destinationBuildingKey = resolvedDestinationRoom.buildingKey;
+          const hasIndoorStartGraph = Boolean(
+            automaticStartBuildingKey && getIndoorGraph(automaticStartBuildingKey),
+          );
+          const shouldRequireIndoorStartRoomSelection = Boolean(
+            automaticStartBuilding && hasIndoorStartGraph,
+          );
+
+          if (shouldRequireIndoorStartRoomSelection && automaticStartBuilding) {
+            setStartBuilding(automaticStartBuilding);
+            setStartLocationSnapshot(null);
+            setStartEndpoint(null);
+            setStartRoom(null);
+            setRouteStartSource('manual');
+            setRequiresIndoorStartRoomSelection(true);
+            onIndoorRouteChange?.(null, null);
+            setActiveView('hybrid-directions');
+            requestAnimationFrame(() => {
+              sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
+            });
+            return null;
+          }
+
+          const stagedStartRoomEndpoint =
+            automaticStartBuilding &&
+            automaticStartBuildingKey &&
+            automaticStartBuildingKey !== destinationBuildingKey
+              ? getTransferRoomEndpoint({
+                  building: automaticStartBuilding,
+                  labelSuffix: 'Entrance',
+                })
+              : null;
+
+          const nextStartEndpoint: MixedEndpoint | null = stagedStartRoomEndpoint
+            ? { kind: 'room', room: stagedStartRoomEndpoint }
+            : automaticStartBuilding
+              ? { kind: 'building', building: automaticStartBuilding }
+              : null;
+
+          setStartEndpoint(nextStartEndpoint);
+          setStartRoom(stagedStartRoomEndpoint?.label ?? automaticStartBuilding?.name ?? null);
+          setRequiresIndoorStartRoomSelection(false);
+
+          const flowResult = buildCrossBuildingRouteFlow({
+            startRoom: stagedStartRoomEndpoint,
+            startBuilding: stagedStartRoomEndpoint ? automaticStartBuilding : null,
+            destinationRoom: resolvedDestinationRoom,
+            destinationBuilding: resolvedDestinationBuilding,
+            buildings,
+            indoorTravelMode,
+            outdoorMode: 'walking',
+          });
+
+          if (!flowResult.ok) {
+            setStartBuilding(automaticStartBuilding ?? null);
+            setStartLocationSnapshot(startPoint.coordinates);
+            setRouteStartSource('current');
+            setHybridRouteErrorMessage(flowResult.message);
+            setRequiresIndoorStartRoomSelection(false);
+            onIndoorRouteChange?.(null, null);
+            setActiveView('hybrid-directions');
+            requestAnimationFrame(() => {
+              sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
+            });
+            return null;
+          }
+
+          const { flow } = flowResult;
+          resetRouteState();
+          startCrossBuildingRouteFlow(flow);
+          setTravelMode(flow.outdoorMode);
+          setRouteStartSource(flow.originBuilding ? 'manual' : 'current');
+          setStartLocationSnapshot(flow.originBuilding ? null : startPoint.coordinates);
+          setStartBuilding(flow.originBuilding);
+          setDestinationBuilding(flow.destinationBuilding);
+          setDestinationLocationSnapshot(null);
+          passSelectedBuilding(
+            flow.currentStage === 'origin_indoor' ? flow.originBuilding : flow.destinationBuilding,
+          );
+
+          if (
+            flow.currentStage === 'origin_indoor' &&
+            flow.startRoomEndpoint &&
+            flow.originTransferPoint &&
+            flow.originBuilding
+          ) {
+            onIndoorRouteChange?.(flow.startRoomEndpoint.id, flow.originTransferPoint.accessNodeId);
+            enterIndoorView();
+            onEnterBuilding(flow.originBuilding);
+            setActiveView('indoor-navigation');
+            requestAnimationFrame(() => {
+              sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
+            });
+            return null;
+          }
+
+          onIndoorRouteChange?.(null, null);
+          resetRouteState();
+          onShowOutdoorMap?.();
+          setActiveView('directions');
           return null;
         } catch {
           return CALENDAR_LOCATION_NOT_FOUND_MESSAGE;
         }
       },
-      [clearCrossBuildingRouteFlowState, onExitSearch, passSelectedBuilding, snapToDirectionsPanel],
+      [
+        buildings,
+        clearCrossBuildingRouteFlowState,
+        enterIndoorView,
+        indoorTravelMode,
+        onEnterBuilding,
+        onExitSearch,
+        onIndoorRouteChange,
+        onShowOutdoorMap,
+        passSelectedBuilding,
+        resetRouteState,
+        snapToDirectionsPanel,
+        startCrossBuildingRouteFlow,
+      ],
     );
 
     const handleInternalSearch = (building: BuildingShape) => {
@@ -1906,6 +2090,11 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
     const handleHybridGo = useCallback(() => {
       setHybridRouteErrorMessage(null);
 
+      if (requiresIndoorStartRoomSelection && !isRoomEndpoint(startEndpoint)) {
+        setHybridRouteErrorMessage('Choose your current room as the start point to continue.');
+        return;
+      }
+
       const hasOutdoorOrigin = Boolean(
         !startEndpoint &&
         (startBuilding || startLocationSnapshot || currentBuilding || userLocation),
@@ -1945,6 +2134,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       const { flow } = result;
       clearCrossBuildingRouteFlowState();
       resetRouteState();
+      setRequiresIndoorStartRoomSelection(false);
       startCrossBuildingRouteFlow(flow);
       setTravelMode(flow.outdoorMode);
       setRouteStartSource(flow.originBuilding ? 'manual' : 'current');
@@ -1991,6 +2181,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       onIndoorRouteChange,
       onShowOutdoorMap,
       passSelectedBuilding,
+      requiresIndoorStartRoomSelection,
       resetRouteState,
       startBuilding,
       startLocationSnapshot,
@@ -2391,16 +2582,18 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       });
     const hybridDestinationLabel =
       getEndpointLabel(destinationEndpoint) ?? destinationRoom ?? destinationBuilding?.name ?? null;
-    const hybridSummaryMessage = getHybridRouteGuidanceMessage(
-      startEndpoint,
-      destinationEndpoint,
-      hasHybridOutdoorOrigin,
-    );
-    const hybridGoDisabled = !canStartMixedHybridRoute({
-      start: startEndpoint,
-      destination: destinationEndpoint,
-      hasOutdoorOrigin: hasHybridOutdoorOrigin,
-    });
+    const requiresIndoorStartRoom =
+      requiresIndoorStartRoomSelection && !isRoomEndpoint(startEndpoint);
+    const hybridSummaryMessage = requiresIndoorStartRoom
+      ? 'Choose your current room as the start point to continue.'
+      : getHybridRouteGuidanceMessage(startEndpoint, destinationEndpoint, hasHybridOutdoorOrigin);
+    const hybridGoDisabled =
+      requiresIndoorStartRoom ||
+      !canStartMixedHybridRoute({
+        start: startEndpoint,
+        destination: destinationEndpoint,
+        hasOutdoorOrigin: hasHybridOutdoorOrigin,
+      });
     const directionDestinationLabel =
       destinationPoi?.name ?? (destinationLocationSnapshot ? 'My Location' : null);
 

--- a/mobile/src/components/BottomSheet.tsx
+++ b/mobile/src/components/BottomSheet.tsx
@@ -41,6 +41,7 @@ import { fetchShuttleCompositeDirections } from '../services/directions/shuttleC
 import type { GoogleCalendarEventItem } from '../services/googleCalendarAuth';
 import {
   CALENDAR_LOCATION_NOT_FOUND_MESSAGE,
+  type CalendarRouteStartPoint,
   getManualStartReasonMessage,
   resolveCalendarRouteLocation,
 } from '../utils/calendarRouteLocation';
@@ -54,6 +55,7 @@ import IndoorNavigationDetails from './indoor/IndoorNavigationDetails';
 import { IndoorRoutePlannerMode } from '../types/SheetMode';
 import type { SearchMode } from '../types/SearchMode';
 import type { OutdoorPoi, PoiCategorySelection, PoiRangeKm } from '../types/Poi';
+import type { CrossBuildingRouteFlow } from '../types/CrossBuildingRoute';
 import HybridDirectionsDetails from './HybridDirectionsDetails';
 import {
   getIndoorBuildingCampus,
@@ -315,6 +317,18 @@ const getTransferRoomEndpoint = ({
     campus: getIndoorBuildingCampus(buildingKey),
     floor: transferNode?.floor ?? 1,
   };
+};
+
+const resolveStartEndpoint = ({
+  roomEndpoint,
+  building,
+}: {
+  roomEndpoint: RoomNode | null;
+  building: BuildingShape | null;
+}): MixedEndpoint | null => {
+  if (roomEndpoint) return { kind: 'room', room: roomEndpoint };
+  if (building) return { kind: 'building', building };
+  return null;
 };
 
 const getEndpointBuildingKey = (endpoint: MixedEndpoint | null): string | null => {
@@ -1563,6 +1577,177 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       snapToDirectionsPanel(DIRECTIONS_PANEL_SNAP_POINT);
     }, [snapToDirectionsPanel]);
 
+    const snapToExpandedPanel = useCallback(() => {
+      requestAnimationFrame(() => {
+        sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
+      });
+    }, []);
+
+    const showExpandedHybridDirectionsPanel = useCallback(() => {
+      setActiveView('hybrid-directions');
+      snapToExpandedPanel();
+    }, [snapToExpandedPanel]);
+
+    const showExpandedIndoorNavigationPanel = useCallback(
+      ({
+        startNodeId,
+        destinationNodeId,
+        building,
+      }: {
+        startNodeId: string;
+        destinationNodeId: string;
+        building: BuildingShape;
+      }) => {
+        onIndoorRouteChange?.(startNodeId, destinationNodeId);
+        enterIndoorView();
+        onEnterBuilding(building);
+        setActiveView('indoor-navigation');
+        snapToExpandedPanel();
+      },
+      [enterIndoorView, onEnterBuilding, onIndoorRouteChange, snapToExpandedPanel],
+    );
+
+    const showOutdoorDirectionsStage = useCallback(() => {
+      onIndoorRouteChange?.(null, null);
+      resetRouteState();
+      onShowOutdoorMap?.();
+      setActiveView('directions');
+    }, [onIndoorRouteChange, onShowOutdoorMap, resetRouteState]);
+
+    const applyCrossBuildingFlowState = useCallback(
+      (flow: CrossBuildingRouteFlow, startCoordinates: UserCoords | null) => {
+        resetRouteState();
+        startCrossBuildingRouteFlow(flow);
+        setTravelMode(flow.outdoorMode);
+        setRouteStartSource(flow.originBuilding ? 'manual' : 'current');
+        setStartLocationSnapshot(flow.originBuilding ? null : startCoordinates);
+        setStartBuilding(flow.originBuilding);
+        setDestinationBuilding(flow.destinationBuilding);
+        setDestinationLocationSnapshot(null);
+        passSelectedBuilding(
+          flow.currentStage === 'origin_indoor' ? flow.originBuilding : flow.destinationBuilding,
+        );
+      },
+      [passSelectedBuilding, resetRouteState, startCrossBuildingRouteFlow],
+    );
+
+    const continueCrossBuildingFlow = useCallback(
+      (flow: CrossBuildingRouteFlow, startCoordinates: UserCoords | null) => {
+        applyCrossBuildingFlowState(flow, startCoordinates);
+
+        if (
+          flow.currentStage === 'origin_indoor' &&
+          flow.startRoomEndpoint &&
+          flow.originTransferPoint &&
+          flow.originBuilding
+        ) {
+          showExpandedIndoorNavigationPanel({
+            startNodeId: flow.startRoomEndpoint.id,
+            destinationNodeId: flow.originTransferPoint.accessNodeId,
+            building: flow.originBuilding,
+          });
+          return;
+        }
+
+        showOutdoorDirectionsStage();
+      },
+      [applyCrossBuildingFlowState, showExpandedIndoorNavigationPanel, showOutdoorDirectionsStage],
+    );
+
+    const initializeCalendarRouteState = useCallback(
+      (destinationBuilding: BuildingShape) => {
+        passSelectedBuilding(destinationBuilding);
+        setCalendarSliderMode(null);
+        setSearchFor(null);
+        onExitSearch();
+        setDestinationPoi(null);
+        setDestinationLocationSnapshot(null);
+        setTravelMode('walking');
+        setHybridOutdoorTravelMode('walking');
+        setRouteErrorMessage(null);
+        setHybridRouteErrorMessage(null);
+        setRequiresIndoorStartRoomSelection(false);
+      },
+      [onExitSearch, passSelectedBuilding],
+    );
+
+    const applyCalendarBuildingDestination = useCallback(
+      (destinationBuilding: BuildingShape, startPoint: CalendarRouteStartPoint): void => {
+        setDestinationBuilding(destinationBuilding);
+        setDestinationEndpoint({ kind: 'building', building: destinationBuilding });
+        setStartEndpoint(null);
+        setStartRoom(null);
+        setDestinationRoom(null);
+        onIndoorRouteChange?.(null, null);
+        setActiveView('directions');
+
+        if (startPoint.type === 'automatic') {
+          setRouteStartSource('current');
+          // Calendar GO should always start from the user's live location coordinates.
+          setStartBuilding(null);
+          setStartLocationSnapshot(startPoint.coordinates);
+        } else {
+          setStartBuilding(null);
+          setStartLocationSnapshot(null);
+          setRouteStartSource('manual');
+          setRouteErrorMessage(getManualStartReasonMessage(startPoint.reason));
+        }
+
+        snapToDirectionsPanel(DIRECTIONS_PANEL_SNAP_POINT);
+      },
+      [onIndoorRouteChange, snapToDirectionsPanel],
+    );
+
+    const applyCalendarManualRoomStart = useCallback(
+      (startPoint: Extract<CalendarRouteStartPoint, { type: 'manual' }>): void => {
+        setStartBuilding(null);
+        setStartLocationSnapshot(null);
+        setStartEndpoint(null);
+        setStartRoom(null);
+        setRouteStartSource('manual');
+        setHybridRouteErrorMessage(getManualStartReasonMessage(startPoint.reason));
+        setRequiresIndoorStartRoomSelection(false);
+        onIndoorRouteChange?.(null, null);
+        showExpandedHybridDirectionsPanel();
+      },
+      [onIndoorRouteChange, showExpandedHybridDirectionsPanel],
+    );
+
+    const promptCalendarStartRoomSelection = useCallback(
+      (startBuildingForSelection: BuildingShape): void => {
+        setStartBuilding(startBuildingForSelection);
+        setStartLocationSnapshot(null);
+        setStartEndpoint(null);
+        setStartRoom(null);
+        setRouteStartSource('manual');
+        setRequiresIndoorStartRoomSelection(true);
+        onIndoorRouteChange?.(null, null);
+        showExpandedHybridDirectionsPanel();
+      },
+      [onIndoorRouteChange, showExpandedHybridDirectionsPanel],
+    );
+
+    const showCalendarFlowBuildError = useCallback(
+      ({
+        startBuildingForError,
+        startCoordinates,
+        message,
+      }: {
+        startBuildingForError: BuildingShape | null;
+        startCoordinates: UserCoords;
+        message: string;
+      }) => {
+        setStartBuilding(startBuildingForError);
+        setStartLocationSnapshot(startCoordinates);
+        setRouteStartSource('current');
+        setHybridRouteErrorMessage(message);
+        setRequiresIndoorStartRoomSelection(false);
+        onIndoorRouteChange?.(null, null);
+        showExpandedHybridDirectionsPanel();
+      },
+      [onIndoorRouteChange, showExpandedHybridDirectionsPanel],
+    );
+
     const handleSelectRoom = useCallback(
       (room: RoomNode) => {
         setHybridRouteErrorMessage(null);
@@ -1801,40 +1986,10 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
             startPoint,
           } = resolved.value;
 
-          passSelectedBuilding(resolvedDestinationBuilding);
-          setCalendarSliderMode(null);
-          setSearchFor(null);
-          onExitSearch();
-          setDestinationPoi(null);
-          setDestinationLocationSnapshot(null);
-          setTravelMode('walking');
-          setHybridOutdoorTravelMode('walking');
-          setRouteErrorMessage(null);
-          setHybridRouteErrorMessage(null);
-          setRequiresIndoorStartRoomSelection(false);
+          initializeCalendarRouteState(resolvedDestinationBuilding);
 
           if (!resolvedDestinationRoomEndpoint) {
-            setDestinationBuilding(resolvedDestinationBuilding);
-            setDestinationEndpoint({ kind: 'building', building: resolvedDestinationBuilding });
-            setStartEndpoint(null);
-            setStartRoom(null);
-            setDestinationRoom(null);
-            onIndoorRouteChange?.(null, null);
-            setActiveView('directions');
-
-            if (startPoint.type === 'automatic') {
-              setRouteStartSource('current');
-              // Calendar GO should always start from the user's live location coordinates.
-              setStartBuilding(null);
-              setStartLocationSnapshot(startPoint.coordinates);
-            } else {
-              setStartBuilding(null);
-              setStartLocationSnapshot(null);
-              setRouteStartSource('manual');
-              setRouteErrorMessage(getManualStartReasonMessage(startPoint.reason));
-            }
-
-            snapToDirectionsPanel(DIRECTIONS_PANEL_SNAP_POINT);
+            applyCalendarBuildingDestination(resolvedDestinationBuilding, startPoint);
             return null;
           }
 
@@ -1844,18 +1999,7 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
           setDestinationRoom(resolvedDestinationRoom.label);
 
           if (startPoint.type !== 'automatic') {
-            setStartBuilding(null);
-            setStartLocationSnapshot(null);
-            setStartEndpoint(null);
-            setStartRoom(null);
-            setRouteStartSource('manual');
-            setHybridRouteErrorMessage(getManualStartReasonMessage(startPoint.reason));
-            setRequiresIndoorStartRoomSelection(false);
-            onIndoorRouteChange?.(null, null);
-            setActiveView('hybrid-directions');
-            requestAnimationFrame(() => {
-              sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
-            });
+            applyCalendarManualRoomStart(startPoint);
             return null;
           }
 
@@ -1865,22 +2009,9 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
           const hasIndoorStartGraph = Boolean(
             automaticStartBuildingKey && getIndoorGraph(automaticStartBuildingKey),
           );
-          const shouldRequireIndoorStartRoomSelection = Boolean(
-            automaticStartBuilding && hasIndoorStartGraph,
-          );
 
-          if (shouldRequireIndoorStartRoomSelection && automaticStartBuilding) {
-            setStartBuilding(automaticStartBuilding);
-            setStartLocationSnapshot(null);
-            setStartEndpoint(null);
-            setStartRoom(null);
-            setRouteStartSource('manual');
-            setRequiresIndoorStartRoomSelection(true);
-            onIndoorRouteChange?.(null, null);
-            setActiveView('hybrid-directions');
-            requestAnimationFrame(() => {
-              sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
-            });
+          if (automaticStartBuilding && hasIndoorStartGraph) {
+            promptCalendarStartRoomSelection(automaticStartBuilding);
             return null;
           }
 
@@ -1894,11 +2025,10 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
                 })
               : null;
 
-          const nextStartEndpoint: MixedEndpoint | null = stagedStartRoomEndpoint
-            ? { kind: 'room', room: stagedStartRoomEndpoint }
-            : automaticStartBuilding
-              ? { kind: 'building', building: automaticStartBuilding }
-              : null;
+          const nextStartEndpoint = resolveStartEndpoint({
+            roomEndpoint: stagedStartRoomEndpoint,
+            building: automaticStartBuilding,
+          });
 
           setStartEndpoint(nextStartEndpoint);
           setStartRoom(stagedStartRoomEndpoint?.label ?? automaticStartBuilding?.name ?? null);
@@ -1915,70 +2045,30 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
           });
 
           if (!flowResult.ok) {
-            setStartBuilding(automaticStartBuilding ?? null);
-            setStartLocationSnapshot(startPoint.coordinates);
-            setRouteStartSource('current');
-            setHybridRouteErrorMessage(flowResult.message);
-            setRequiresIndoorStartRoomSelection(false);
-            onIndoorRouteChange?.(null, null);
-            setActiveView('hybrid-directions');
-            requestAnimationFrame(() => {
-              sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
+            showCalendarFlowBuildError({
+              startBuildingForError: automaticStartBuilding,
+              startCoordinates: startPoint.coordinates,
+              message: flowResult.message,
             });
             return null;
           }
 
-          const { flow } = flowResult;
-          resetRouteState();
-          startCrossBuildingRouteFlow(flow);
-          setTravelMode(flow.outdoorMode);
-          setRouteStartSource(flow.originBuilding ? 'manual' : 'current');
-          setStartLocationSnapshot(flow.originBuilding ? null : startPoint.coordinates);
-          setStartBuilding(flow.originBuilding);
-          setDestinationBuilding(flow.destinationBuilding);
-          setDestinationLocationSnapshot(null);
-          passSelectedBuilding(
-            flow.currentStage === 'origin_indoor' ? flow.originBuilding : flow.destinationBuilding,
-          );
-
-          if (
-            flow.currentStage === 'origin_indoor' &&
-            flow.startRoomEndpoint &&
-            flow.originTransferPoint &&
-            flow.originBuilding
-          ) {
-            onIndoorRouteChange?.(flow.startRoomEndpoint.id, flow.originTransferPoint.accessNodeId);
-            enterIndoorView();
-            onEnterBuilding(flow.originBuilding);
-            setActiveView('indoor-navigation');
-            requestAnimationFrame(() => {
-              sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
-            });
-            return null;
-          }
-
-          onIndoorRouteChange?.(null, null);
-          resetRouteState();
-          onShowOutdoorMap?.();
-          setActiveView('directions');
+          continueCrossBuildingFlow(flowResult.flow, startPoint.coordinates);
           return null;
         } catch {
           return CALENDAR_LOCATION_NOT_FOUND_MESSAGE;
         }
       },
       [
+        applyCalendarBuildingDestination,
+        applyCalendarManualRoomStart,
         buildings,
         clearCrossBuildingRouteFlowState,
-        enterIndoorView,
+        continueCrossBuildingFlow,
         indoorTravelMode,
-        onEnterBuilding,
-        onExitSearch,
-        onIndoorRouteChange,
-        onShowOutdoorMap,
-        passSelectedBuilding,
-        resetRouteState,
-        snapToDirectionsPanel,
-        startCrossBuildingRouteFlow,
+        initializeCalendarRouteState,
+        promptCalendarStartRoomSelection,
+        showCalendarFlowBuildError,
       ],
     );
 
@@ -2131,61 +2221,21 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
         return;
       }
 
-      const { flow } = result;
       clearCrossBuildingRouteFlowState();
-      resetRouteState();
       setRequiresIndoorStartRoomSelection(false);
-      startCrossBuildingRouteFlow(flow);
-      setTravelMode(flow.outdoorMode);
-      setRouteStartSource(flow.originBuilding ? 'manual' : 'current');
-      setStartLocationSnapshot(
-        flow.originBuilding ? null : (startLocationSnapshot ?? userLocation),
-      );
-      setStartBuilding(flow.originBuilding);
-      setDestinationBuilding(flow.destinationBuilding);
-      setDestinationLocationSnapshot(null);
-      passSelectedBuilding(
-        flow.currentStage === 'origin_indoor' ? flow.originBuilding : flow.destinationBuilding,
-      );
-
-      if (
-        flow.currentStage === 'origin_indoor' &&
-        flow.startRoomEndpoint &&
-        flow.originTransferPoint &&
-        flow.originBuilding
-      ) {
-        onIndoorRouteChange?.(flow.startRoomEndpoint.id, flow.originTransferPoint.accessNodeId);
-        enterIndoorView();
-        onEnterBuilding(flow.originBuilding);
-        setActiveView('indoor-navigation');
-        requestAnimationFrame(() => {
-          sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
-        });
-        return;
-      }
-
-      onIndoorRouteChange?.(null, null);
-      resetRouteState();
-      onShowOutdoorMap?.();
-      setActiveView('directions');
+      continueCrossBuildingFlow(result.flow, startLocationSnapshot ?? userLocation);
     }, [
       buildings,
       clearCrossBuildingRouteFlowState,
+      continueCrossBuildingFlow,
       currentBuilding,
       destinationBuilding,
       destinationEndpoint,
-      enterIndoorView,
       hybridOutdoorTravelMode,
       indoorTravelMode,
-      onEnterBuilding,
-      onIndoorRouteChange,
-      onShowOutdoorMap,
-      passSelectedBuilding,
       requiresIndoorStartRoomSelection,
-      resetRouteState,
       startBuilding,
       startLocationSnapshot,
-      startCrossBuildingRouteFlow,
       startEndpoint,
       userLocation,
     ]);
@@ -2203,16 +2253,11 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       setStartBuilding(flow.originBuilding);
       setDestinationBuilding(flow.destinationBuilding);
       setDestinationLocationSnapshot(null);
-      onIndoorRouteChange?.(null, null);
-      resetRouteState();
-      onShowOutdoorMap?.();
-      setActiveView('directions');
+      showOutdoorDirectionsStage();
     }, [
       continueCrossBuildingRouteFlowToOutdoor,
       crossBuildingRouteFlow,
-      onIndoorRouteChange,
-      onShowOutdoorMap,
-      resetRouteState,
+      showOutdoorDirectionsStage,
     ]);
 
     const handleEnterDestinationBuilding = useCallback(() => {
@@ -2228,24 +2273,17 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
       continueCrossBuildingRouteFlowToDestinationIndoor();
       resetRouteState();
       passSelectedBuilding(flow.destinationBuilding);
-      onIndoorRouteChange?.(
-        flow.destinationTransferPoint.accessNodeId,
-        flow.destinationRoomEndpoint.id,
-      );
-      enterIndoorView();
-      onEnterBuilding(flow.destinationBuilding);
-      setActiveView('indoor-navigation');
-      requestAnimationFrame(() => {
-        sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
+      showExpandedIndoorNavigationPanel({
+        startNodeId: flow.destinationTransferPoint.accessNodeId,
+        destinationNodeId: flow.destinationRoomEndpoint.id,
+        building: flow.destinationBuilding,
       });
     }, [
       continueCrossBuildingRouteFlowToDestinationIndoor,
       crossBuildingRouteFlow,
-      enterIndoorView,
-      onEnterBuilding,
-      onIndoorRouteChange,
       passSelectedBuilding,
       resetRouteState,
+      showExpandedIndoorNavigationPanel,
     ]);
 
     const handleCrossBuildingIndoorBack = useCallback(() => {
@@ -2560,11 +2598,11 @@ const BottomSlider = forwardRef<BottomSliderHandle, BottomSheetProps>(
             ? 'hybrid-directions'
             : 'indoor-directions',
         );
-        sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
+        snapToExpandedPanel();
       },
       openIndoorNavigation: () => {
         setActiveView('indoor-navigation');
-        sheetRef.current?.snapToIndex(SHEET_INDEX_EXPANDED);
+        snapToExpandedPanel();
       },
     }));
 

--- a/mobile/src/utils/calendarRouteLocation.ts
+++ b/mobile/src/utils/calendarRouteLocation.ts
@@ -65,7 +65,8 @@ const WHITESPACE_PATTERN = /\s+/g;
 const CAMPUS_PREFIX_PATTERN = /\b(SGW|LOY|LOYOLA)\b/g;
 const NON_ALPHANUMERIC_PATTERN = /[^A-Z0-9]/g;
 const ROOM_LABEL_TOKEN_PATTERN = /[A-Z0-9]+/g;
-const ROOM_TOKEN_SEPARATOR_PATTERN = '[\\s.,;:()[\\]{}_-]*';
+const ROOM_TOKEN_SEPARATOR_PATTERN = String.raw`[\s.,;:()[\]{}_-]*`;
+const REGEX_ESCAPE_REPLACEMENT = String.raw`\$&`;
 
 const normalizeText = (value: string) =>
   value
@@ -81,7 +82,8 @@ const normalizeWithoutCampusPrefix = (value: string) =>
 const normalizeCode = (value: string) =>
   value.toUpperCase().replaceAll(NON_ALPHANUMERIC_PATTERN, '');
 
-const escapeRegex = (value: string) => value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const escapeRegex = (value: string) =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/g, REGEX_ESCAPE_REPLACEMENT);
 
 const isUppercaseLetter = (char: string) => char >= 'A' && char <= 'Z';
 const isDigit = (char: string) => char >= '0' && char <= '9';

--- a/mobile/src/utils/calendarRouteLocation.ts
+++ b/mobile/src/utils/calendarRouteLocation.ts
@@ -1,6 +1,13 @@
 import { getAllBuildingShapes, findBuildingAt } from './buildingsRepository';
 import { getCurrentLocationResult } from './location';
+import { getIndoorGraph } from './indoor/indoorGraphs';
+import {
+  getIndoorBuildingCampus,
+  getIndoorBuildingKeyFromShape,
+  type IndoorBuildingKey,
+} from './indoor/buildingKeys';
 import type { BuildingShape } from '../types/BuildingShape';
+import type { CrossBuildingRoomEndpoint } from '../types/CrossBuildingRoute';
 import type { UserLocationCoords } from './location';
 
 type DestinationMatchMethod = 'short_code' | 'name' | 'address';
@@ -22,6 +29,7 @@ export type CalendarRouteStartPoint = AutomaticStartPoint | ManualStartPoint;
 
 export type CalendarRouteLocation = {
   destinationBuilding: BuildingShape;
+  destinationRoomEndpoint: CrossBuildingRoomEndpoint | null;
   startPoint: CalendarRouteStartPoint;
   normalizedEventLocation: string;
   rawEventLocation: string;
@@ -56,6 +64,8 @@ const PUNCTUATION_PATTERN = /[.,;:()[\]{}]/g;
 const WHITESPACE_PATTERN = /\s+/g;
 const CAMPUS_PREFIX_PATTERN = /\b(SGW|LOY|LOYOLA)\b/g;
 const NON_ALPHANUMERIC_PATTERN = /[^A-Z0-9]/g;
+const ROOM_LABEL_TOKEN_PATTERN = /[A-Z0-9]+/g;
+const ROOM_TOKEN_SEPARATOR_PATTERN = '[\\s.,;:()[\\]{}_-]*';
 
 const normalizeText = (value: string) =>
   value
@@ -70,6 +80,8 @@ const normalizeWithoutCampusPrefix = (value: string) =>
 
 const normalizeCode = (value: string) =>
   value.toUpperCase().replaceAll(NON_ALPHANUMERIC_PATTERN, '');
+
+const escapeRegex = (value: string) => value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const isUppercaseLetter = (char: string) => char >= 'A' && char <= 'Z';
 const isDigit = (char: string) => char >= '0' && char <= '9';
@@ -330,6 +342,129 @@ const matchDestinationBuilding = (
   );
 };
 
+type RoomLabelCandidate = {
+  endpoint: CrossBuildingRoomEndpoint;
+  canonicalLabel: string;
+  pattern: RegExp;
+  tokenCount: number;
+  labelLength: number;
+};
+
+const roomCandidatesByBuildingKey = new Map<IndoorBuildingKey, RoomLabelCandidate[]>();
+
+const toRoomLabelTokens = (value: string): string[] =>
+  value.toUpperCase().match(ROOM_LABEL_TOKEN_PATTERN) ?? [];
+
+const buildRoomLabelPattern = (tokens: string[]) =>
+  new RegExp(
+    `(^|[^A-Z0-9])${tokens.map((token) => escapeRegex(token)).join(ROOM_TOKEN_SEPARATOR_PATTERN)}(?=$|[^A-Z0-9])`,
+    'i',
+  );
+
+const getRoomLabelCandidates = (
+  destinationBuilding: BuildingShape,
+  buildingKey: IndoorBuildingKey,
+): RoomLabelCandidate[] => {
+  const cachedCandidates = roomCandidatesByBuildingKey.get(buildingKey);
+  if (cachedCandidates) return cachedCandidates;
+
+  const graph = getIndoorGraph(buildingKey);
+  if (!graph) {
+    roomCandidatesByBuildingKey.set(buildingKey, []);
+    return [];
+  }
+
+  const candidates: RoomLabelCandidate[] = [];
+  const seenCanonicalLabels = new Set<string>();
+  const roomCampus = getIndoorBuildingCampus(buildingKey) ?? destinationBuilding.campus ?? null;
+
+  for (const node of graph.nodes) {
+    if (node.type !== 'room') continue;
+
+    const label = node.label.trim();
+    if (!label) continue;
+
+    const canonicalLabel = normalizeCode(label);
+    if (!canonicalLabel || seenCanonicalLabels.has(canonicalLabel)) continue;
+
+    const tokens = toRoomLabelTokens(label);
+    if (tokens.length < 2) continue;
+
+    candidates.push({
+      endpoint: {
+        id: node.id,
+        label,
+        buildingId: node.buildingId,
+        buildingKey,
+        campus: roomCampus,
+        floor: node.floor,
+      },
+      canonicalLabel,
+      pattern: buildRoomLabelPattern(tokens),
+      tokenCount: tokens.length,
+      labelLength: label.length,
+    });
+    seenCanonicalLabels.add(canonicalLabel);
+  }
+
+  roomCandidatesByBuildingKey.set(buildingKey, candidates);
+  return candidates;
+};
+
+const scoreRoomLabelCandidate = ({
+  candidate,
+  uppercaseRawLocation,
+  canonicalLocation,
+}: {
+  candidate: RoomLabelCandidate;
+  uppercaseRawLocation: string;
+  canonicalLocation: string;
+}) => {
+  let matchScore = 0;
+  if (candidate.pattern.test(uppercaseRawLocation)) matchScore += 3;
+  if (canonicalLocation.includes(candidate.canonicalLabel)) matchScore += 2;
+  if (canonicalLocation === candidate.canonicalLabel) matchScore += 1;
+  if (matchScore === 0) return -1;
+
+  return matchScore * 10_000 + candidate.canonicalLabel.length * 100 + candidate.tokenCount * 10;
+};
+
+const resolveDestinationRoomEndpoint = ({
+  destinationBuilding,
+  rawEventLocation,
+  normalizedEventLocation,
+}: {
+  destinationBuilding: BuildingShape;
+  rawEventLocation: string;
+  normalizedEventLocation: string;
+}): CrossBuildingRoomEndpoint | null => {
+  const destinationBuildingKey = getIndoorBuildingKeyFromShape(destinationBuilding);
+  if (!destinationBuildingKey) return null;
+
+  const candidates = getRoomLabelCandidates(destinationBuilding, destinationBuildingKey);
+  if (candidates.length === 0) return null;
+
+  const uppercaseRawLocation = rawEventLocation.toUpperCase();
+  const canonicalLocation = normalizeCode(normalizedEventLocation);
+
+  let bestMatch: { candidate: RoomLabelCandidate; score: number } | null = null;
+
+  for (const candidate of candidates) {
+    const score = scoreRoomLabelCandidate({
+      candidate,
+      uppercaseRawLocation,
+      canonicalLocation,
+    });
+    if (score < 0) continue;
+
+    if (!bestMatch || score > bestMatch.score) {
+      bestMatch = { candidate, score };
+    }
+  }
+
+  return bestMatch?.candidate.endpoint ?? null;
+};
+
 const resolveStartPoint = async (): Promise<CalendarRouteStartPoint> => {
   const currentLocationResult = await getCurrentLocationResult();
 
@@ -355,13 +490,10 @@ const resolveStartPoint = async (): Promise<CalendarRouteStartPoint> => {
 };
 
 export const getManualStartReasonMessage = (reason: ManualStartReason): string => {
-  if (reason === 'permission_denied') {
-    return 'Location permission required—please select your starting building manually';
-  }
   if (reason === 'location_unavailable') {
     return 'Could not generate route—try again';
   }
-  return 'Location permission required—please select your starting building manually';
+  return '';
 };
 
 export const resolveCalendarEventDestination = (
@@ -379,10 +511,17 @@ export const resolveCalendarEventDestination = (
     return toCalendarLocationError('UNRECOGNIZED_EVENT_LOCATION');
   }
 
+  const destinationRoomEndpoint = resolveDestinationRoomEndpoint({
+    destinationBuilding: destinationMatch.building,
+    rawEventLocation,
+    normalizedEventLocation,
+  });
+
   return {
     type: 'success',
     value: {
       destinationBuilding: destinationMatch.building,
+      destinationRoomEndpoint,
       normalizedEventLocation,
       rawEventLocation,
     },


### PR DESCRIPTION
## Summary
This PR cleans up the calendar GO + hybrid navigation flow.

## What Changed
- Connected the outdoor navigation logic to the indoor one so now when the user has a specific class on their calendar they get the full route navigation to the specific classroom in a building instead of getting the navigation to the building the classroom is located at.

## Validation
- `npx eslint src/components/BottomSheet.tsx src/utils/calendarRouteLocation.ts __test__/BottomSheet.test.tsx __test__/calendarRouteLocation.test.ts`
- `npm test -- --runInBand __test__/BottomSheet.test.tsx __test__/calendarRouteLocation.test.ts`
- `npm test -- --runInBand --coverage`
